### PR TITLE
Add release artifact pipeline and docs

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -1,0 +1,61 @@
+name: Release Artifact
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-artifact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify release artifact
+        run: npm run release:verify
+
+      - name: Read release version
+        id: release_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name.split('/').pop()")
+          echo "artifact_name=$NAME-$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Upload staged artifact folder
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release_version.outputs.artifact_name }}
+          path: artifacts/${{ steps.release_version.outputs.artifact_name }}
+
+      - name: Upload packaged archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.release_version.outputs.artifact_name }}-archive
+          path: artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz
+
+      - name: Attach archive to tagged GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
+          gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Starter-template source artifact release."
+          gh release upload "$TAG_NAME" "$ARCHIVE_PATH" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .env
 .env.*
+artifacts/

--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ Current scaffold:
 - minimal starter package metadata
 - placeholder app entry under `src/`
 - ready to be expanded into a real template repo
+
+## Current release artifact
+
+This starter repo now has a bounded template-source release artifact.
+
+Current local commands:
+- `npm test`
+- `npm run release:artifact`
+- `npm run release:verify`
+
+Current shipped artifact contents are documented in:
+- `docs/release-artifact.md`
+
+Current honest label:
+- this repo ships a starter-template source bundle, not a built production web app

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -1,0 +1,49 @@
+# Release artifact
+
+This repo currently ships a bounded **starter-template source artifact**.
+
+That means the release file is intended to give downstream teams a downloadable starting repo shape, not a built production application.
+
+## What ships
+
+The staged artifact includes the current starter-template source files:
+- `.gitignore`
+- `.github/`
+- `README.md`
+- `package.json`
+- `package-lock.json`
+- `src/`
+- `docs/`
+- `scripts/`
+- `tests/`
+- generated `release-artifact.json`
+
+## What the artifact proves
+
+The artifact proves:
+- the template repo can be packaged repeatably
+- the packaged template contains the documented starter files
+- the staged starter can still run `npm start`
+- GitHub Actions can upload the artifact and attach the archive to tagged releases
+
+## Commands
+
+Stage the artifact:
+
+```bash
+npm run release:artifact
+```
+
+Stage and verify the artifact:
+
+```bash
+npm run release:verify
+```
+
+## Honest current label
+
+This is a:
+
+**starter-template source artifact**
+
+It is not yet a built deployable web application artifact.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@service-lasso/service-lasso-app-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@service-lasso/service-lasso-app-web",
+      "version": "0.1.0",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "node --test tests/**/*.test.js",
+    "release:artifact": "node scripts/release-artifact.mjs",
+    "release:verify": "node scripts/release-verify.mjs"
   }
 }

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -1,0 +1,193 @@
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+const CANDIDATE_RELEASE_PATHS = [
+  ".gitignore",
+  ".github",
+  "README.md",
+  "package.json",
+  "package-lock.json",
+  "src",
+  "src-tauri",
+  "docs",
+  "scripts",
+  "tests",
+];
+
+export async function readRootPackageJson(repoRoot) {
+  return JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+}
+
+export async function getReleaseVersion(repoRoot) {
+  const packageJson = await readRootPackageJson(repoRoot);
+  return packageJson.version;
+}
+
+export async function getArtifactName(repoRoot, version) {
+  const packageJson = await readRootPackageJson(repoRoot);
+  const packageSuffix = packageJson.name.split("/").at(-1);
+  return `${packageSuffix}-${version}`;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getReleaseFiles(repoRoot) {
+  const releaseFiles = [];
+
+  for (const relativePath of CANDIDATE_RELEASE_PATHS) {
+    if (await pathExists(path.join(repoRoot, relativePath))) {
+      releaseFiles.push(relativePath);
+    }
+  }
+
+  return releaseFiles;
+}
+
+async function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      ...options,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function copyReleasePath(repoRoot, artifactRoot, relativePath) {
+  const sourcePath = path.join(repoRoot, relativePath);
+  const targetPath = path.join(artifactRoot, relativePath);
+
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await cp(sourcePath, targetPath, { recursive: true });
+}
+
+async function writeReleaseManifest({ repoRoot, artifactRoot, artifactName, version, releaseFiles }) {
+  const packageJson = await readRootPackageJson(repoRoot);
+  const manifest = {
+    artifactName,
+    version,
+    packageName: packageJson.name,
+    artifactKind: "starter-template-source",
+    shippedFiles: releaseFiles,
+    entrypoint: "src/index.js",
+    notes: [
+      "This artifact is a starter-template source bundle.",
+      "It is not yet a built production application artifact.",
+    ],
+  };
+
+  await writeFile(
+    path.join(artifactRoot, "release-artifact.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+
+  return manifest;
+}
+
+async function createReleaseArchive(outputRoot, artifactName) {
+  const archivePath = path.join(outputRoot, `${artifactName}.tar.gz`);
+  await rm(archivePath, { force: true });
+  await runCommand("tar", ["-czf", archivePath, "-C", outputRoot, artifactName]);
+  return archivePath;
+}
+
+export async function stageReleaseArtifact({ repoRoot, outputRoot = path.join(repoRoot, "artifacts"), version } = {}) {
+  const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
+  const artifactName = await getArtifactName(repoRoot, resolvedVersion);
+  const artifactRoot = path.join(outputRoot, artifactName);
+  const releaseFiles = await getReleaseFiles(repoRoot);
+
+  await rm(artifactRoot, { recursive: true, force: true });
+  await mkdir(outputRoot, { recursive: true });
+
+  for (const relativePath of releaseFiles) {
+    await copyReleasePath(repoRoot, artifactRoot, relativePath);
+  }
+
+  const manifest = await writeReleaseManifest({
+    repoRoot,
+    artifactRoot,
+    artifactName,
+    version: resolvedVersion,
+    releaseFiles,
+  });
+  const archivePath = await createReleaseArchive(outputRoot, artifactName);
+
+  return {
+    artifactName,
+    artifactRoot,
+    archivePath,
+    manifest,
+  };
+}
+
+export async function verifyStagedArtifact({ repoRoot, artifactRoot, archivePath, version } = {}) {
+  const resolvedVersion = version ?? (await getReleaseVersion(repoRoot));
+  const artifactName = await getArtifactName(repoRoot, resolvedVersion);
+  const stagedRoot = artifactRoot ?? path.join(repoRoot, "artifacts", artifactName);
+  const stagedArchivePath = archivePath ?? path.join(repoRoot, "artifacts", `${artifactName}.tar.gz`);
+  const releaseFiles = await getReleaseFiles(repoRoot);
+
+  await stat(stagedArchivePath);
+  await stat(path.join(stagedRoot, "release-artifact.json"));
+
+  for (const relativePath of releaseFiles) {
+    await stat(path.join(stagedRoot, relativePath));
+  }
+
+  const packageJson = await readRootPackageJson(repoRoot);
+  const expectedNeedle = packageJson.name.split("/").at(-1);
+  const result = await runCommand(process.execPath, [path.join(stagedRoot, "src", "index.js")], {
+    cwd: stagedRoot,
+    env: process.env,
+  });
+
+  if (!result.stdout.includes(expectedNeedle)) {
+    throw new Error(`staged starter output did not include expected repo marker: ${expectedNeedle}`);
+  }
+
+  return {
+    artifactName,
+    stagedRoot,
+    stagedArchivePath,
+    smoke: result.stdout,
+  };
+}
+
+export async function createTemporaryOutputRoot(prefix = "service-lasso-template-release-") {
+  return mkdtemp(path.join(os.tmpdir(), prefix));
+}

--- a/scripts/release-artifact.mjs
+++ b/scripts/release-artifact.mjs
@@ -1,0 +1,11 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { stageReleaseArtifact } from "./release-artifact-lib.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const result = await stageReleaseArtifact({ repoRoot });
+
+console.log("[service-lasso starter] staged release artifact");
+console.log(`- artifact: ${result.artifactName}`);
+console.log(`- folder: ${result.artifactRoot}`);
+console.log(`- archive: ${result.archivePath}`);

--- a/scripts/release-verify.mjs
+++ b/scripts/release-verify.mjs
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { stageReleaseArtifact, verifyStagedArtifact } from "./release-artifact-lib.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const staged = await stageReleaseArtifact({ repoRoot });
+const verified = await verifyStagedArtifact({
+  repoRoot,
+  artifactRoot: staged.artifactRoot,
+  archivePath: staged.archivePath,
+});
+
+console.log("[service-lasso starter] verified release artifact");
+console.log(`- artifact: ${verified.artifactName}`);
+console.log(`- folder: ${verified.stagedRoot}`);
+console.log(`- archive: ${verified.stagedArchivePath}`);

--- a/tests/release-artifact.test.js
+++ b/tests/release-artifact.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { rm } from "node:fs/promises";
+import {
+  createTemporaryOutputRoot,
+  readRootPackageJson,
+  stageReleaseArtifact,
+  verifyStagedArtifact,
+} from "../scripts/release-artifact-lib.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("starter release artifact can be staged and verified", async () => {
+  const outputRoot = await createTemporaryOutputRoot();
+
+  try {
+    const packageJson = await readRootPackageJson(repoRoot);
+    const packageSuffix = packageJson.name.split("/").at(-1);
+    const staged = await stageReleaseArtifact({
+      repoRoot,
+      outputRoot,
+    });
+
+    assert.match(staged.artifactName, new RegExp(`^${packageSuffix}-\\d+\\.\\d+\\.\\d+$`));
+    assert.equal(staged.manifest.artifactKind, "starter-template-source");
+
+    const verified = await verifyStagedArtifact({
+      repoRoot,
+      artifactRoot: staged.artifactRoot,
+      archivePath: staged.archivePath,
+    });
+
+    assert.equal(verified.artifactName, staged.artifactName);
+  } finally {
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add explicit starter-template release artifact docs and scripts
- add a release artifact workflow for GitHub Actions
- add test coverage for staging and verifying the starter artifact

## Verification
- npm test
- npm run release:verify