### PR TITLE
Implement app-web runtime host POC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Check out repo
@@ -19,9 +22,15 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: https://npm.pkg.github.com
+          scope: "@service-lasso"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Run tests
         run: npm test
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
 
     steps:
       - name: Check out repo
@@ -21,15 +22,23 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: https://npm.pkg.github.com
+          scope: "@service-lasso"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Run tests
         run: npm test
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Verify release artifact
         run: npm run release:verify
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Read release version
         id: release_version

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .env
 .env.*
 artifacts/
+.workspace/
+*.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@service-lasso:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Package identity:
 - `@service-lasso/service-lasso-app-web`
 
 Purpose:
-- show how a browser-facing app should consume the Service Lasso runtime/API
+- show how a browser-facing app should consume and host the Service Lasso runtime/API
 - act as a quick-start template for downstream teams
 - keep UI concerns out of the core `service-lasso` repo
 
@@ -14,10 +14,20 @@ Expected runtime model:
 - `servicesRoot`
 - `workspaceRoot`
 
-Current scaffold:
-- minimal starter package metadata
-- placeholder app entry under `src/`
-- ready to be expanded into a real template repo
+Current implementation:
+- browser-first host entrypoint under `src/index.js`
+- published `@service-lasso/service-lasso` runtime package consumption
+- host-owned landing shell at `/`
+- embedded sibling `lasso-@serviceadmin` build at `/admin/`
+- prepared local `servicesRoot` wrapper for sibling `lasso-echoservice`
+
+Current local start command:
+- `npm start`
+
+Current local URLs:
+- web shell: `http://127.0.0.1:19120`
+- embedded admin UI: `http://127.0.0.1:19120/admin/`
+- runtime API: `http://127.0.0.1:18081`
 
 ## Current release artifact
 
@@ -40,7 +50,7 @@ Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`
 
 Current honest label:
-- this repo ships a starter-template source bundle, not a built production web app
+- this repo ships a runnable browser-first host starter plus a starter-template source bundle
 
 ## Minimal POC
 

--- a/docs/minimal-poc.md
+++ b/docs/minimal-poc.md
@@ -60,6 +60,14 @@ The POC should:
 - documented host-owned output or shell framing
 - one short smoke checklist proving the flow works
 
+## Current status
+
+This bounded POC is now implemented in-repo:
+- `npm start` boots the published `@service-lasso/service-lasso` runtime
+- the host serves its own browser shell at `/`
+- the host embeds the sibling built `lasso-@serviceadmin` app at `/admin/`
+- the host prepares a local wrapper `servicesRoot` so `lasso-echoservice` is the discovered service under test
+
 ## Honest scope limit
 
 This POC does not need:

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -8,6 +8,7 @@ That means the release file is intended to give downstream teams a downloadable 
 
 The staged artifact includes the current starter-template source files:
 - `.gitignore`
+- `.npmrc`
 - `.github/`
 - `README.md`
 - `package.json`
@@ -23,8 +24,18 @@ The staged artifact includes the current starter-template source files:
 The artifact proves:
 - the template repo can be packaged repeatably
 - the packaged template contains the documented starter files
-- the staged starter can still run `npm start`
+- the staged starter can install the core runtime package and still run `npm start`
 - GitHub Actions can upload the artifact and attach the archive to tagged releases
+
+## Private package note
+
+This starter depends on the published private core package:
+- `@service-lasso/service-lasso`
+
+For local or CI installs from GitHub Packages, provide a token with package read access through:
+- `NODE_AUTH_TOKEN`
+
+The repo `.npmrc` is included in the staged artifact so the starter knows which registry and scope to use.
 
 ## Commands
 

--- a/docs/task-list.md
+++ b/docs/task-list.md
@@ -1,0 +1,56 @@
+# App Web task list
+
+This document tracks the first real implementation slice for `service-lasso-app-web`.
+
+## Goal
+
+Turn the starter into the smallest real browser-first host that:
+- uses published `@service-lasso/service-lasso`
+- shows host-owned web output
+- embeds `lasso-@serviceadmin`
+- discovers real `lasso-echoservice`
+
+## Bounded tasks
+
+1. Add package-registry wiring for `@service-lasso/service-lasso`
+   status: done
+
+2. Define deterministic local runtime/host ports and sibling-repo path assumptions
+   status: done
+
+3. Replace the placeholder entrypoint with a real web host bootstrap
+   status: done
+
+4. Serve a host-owned web shell with embedded admin UI and runtime links
+   status: done
+
+5. Mount the built Service Admin app from the sibling repo
+   status: done
+
+6. Prepare a local wrapper `servicesRoot` for Echo Service
+   status: done
+
+7. Add direct tests for config resolution, host routes, and wrapper materialization
+   status: done
+
+8. Prove local start behavior against the current workspace
+   status: done
+
+## Honest current scope
+
+This slice does not yet build a production SPA framework host or deployment setup.
+
+It only proves:
+
+**a browser-first host can boot the published runtime, embed Service Admin, and surface Echo Service through a local web shell**
+
+## Current evidence
+
+- `npm test`
+- `npm run release:verify`
+- local smoke:
+  - web shell on `http://127.0.0.1:19120`
+  - runtime API on `http://127.0.0.1:18081`
+  - embedded admin UI on `/admin/`
+  - discovered service id: `echo-service`
+  - install/config/start/stop exercised against the real sibling `lasso-echoservice`

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "test": "node --test tests/**/*.test.js",
     "release:artifact": "node scripts/release-artifact.mjs",
     "release:verify": "node scripts/release-verify.mjs"
+  },
+  "dependencies": {
+    "@service-lasso/service-lasso": "^0.1.0"
   }
 }

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 
 const CANDIDATE_RELEASE_PATHS = [
   ".gitignore",
+  ".npmrc",
   ".github",
   "README.md",
   "package.json",
@@ -86,6 +87,27 @@ async function runCommand(command, args, options = {}) {
   });
 }
 
+const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm";
+
+function escapeWindowsCmdArg(value) {
+  if (/^[A-Za-z0-9_./:=@\\-]+$/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+async function runNpmCommand(args, options = {}) {
+  if (process.platform !== "win32") {
+    return runCommand(NPM_COMMAND, args, options);
+  }
+
+  const comspec = process.env.ComSpec ?? "cmd.exe";
+  const commandLine = [NPM_COMMAND, ...args].map(escapeWindowsCmdArg).join(" ");
+
+  return runCommand(comspec, ["/d", "/s", "/c", commandLine], options);
+}
+
 async function copyReleasePath(repoRoot, artifactRoot, relativePath) {
   const sourcePath = path.join(repoRoot, relativePath);
   const targetPath = path.join(artifactRoot, relativePath);
@@ -123,6 +145,197 @@ async function createReleaseArchive(outputRoot, artifactName) {
   await rm(archivePath, { force: true });
   await runCommand("tar", ["-czf", archivePath, "-C", outputRoot, artifactName]);
   return archivePath;
+}
+
+async function getLocalCorePackageArchive(repoRoot) {
+  const coreRepoRoot = path.resolve(repoRoot, "..", "service-lasso");
+
+  if (!(await pathExists(path.join(coreRepoRoot, "package.json")))) {
+    return null;
+  }
+
+  const corePackageJson = JSON.parse(await readFile(path.join(coreRepoRoot, "package.json"), "utf8"));
+  const version = corePackageJson.version;
+  const artifactRoot = path.join(coreRepoRoot, "artifacts", "npm", `service-lasso-package-${version}`);
+  const archivePath = path.join(artifactRoot, `service-lasso-service-lasso-${version}.tgz`);
+
+  if (!(await pathExists(archivePath))) {
+    await runNpmCommand(["run", "package:stage"], {
+      cwd: coreRepoRoot,
+      env: process.env,
+    });
+  }
+
+  await stat(archivePath);
+  return archivePath;
+}
+
+async function installStarterDependencies(stagedRoot, repoRoot) {
+  const localCorePackageArchive = await getLocalCorePackageArchive(repoRoot);
+
+  if (localCorePackageArchive) {
+    await runNpmCommand(["install", localCorePackageArchive], {
+      cwd: stagedRoot,
+      env: process.env,
+    });
+    return;
+  }
+
+  await runNpmCommand(["install"], {
+    cwd: stagedRoot,
+    env: process.env,
+  });
+}
+
+async function createVerificationSiblingFixtures(stagedRoot) {
+  const siblingRoot = path.resolve(stagedRoot, "..");
+  const adminDistRoot = path.join(siblingRoot, "lasso-@serviceadmin", "dist");
+  const servicesRoot = path.join(siblingRoot, "services");
+  const echoServiceRoot = path.join(siblingRoot, "lasso-echoservice");
+
+  await mkdir(adminDistRoot, { recursive: true });
+  await mkdir(echoServiceRoot, { recursive: true });
+  await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>serviceadmin</title>", "utf8");
+  await writeFile(
+    path.join(echoServiceRoot, "service.json"),
+    `${JSON.stringify(
+      {
+        id: "echo-service",
+        name: "Echo Service",
+        description: "Verification harness service for the starter artifact.",
+        version: "0.0.0",
+        enabled: true,
+        executable: "go",
+        args: ["run", "."],
+        healthcheck: {
+          type: "process",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  await mkdir(servicesRoot, { recursive: true });
+
+  return {
+    siblingRoot,
+    adminDistRoot,
+    echoServiceRoot,
+    servicesRoot,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForJson(url, timeoutMs = 15000) {
+  const startedAt = Date.now();
+  let lastError = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return await response.json();
+      }
+      lastError = new Error(`unexpected status ${response.status} from ${url}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(250);
+  }
+
+  throw lastError ?? new Error(`timed out waiting for ${url}`);
+}
+
+async function smokeStarterHost(stagedRoot, env) {
+  return new Promise((resolve, reject) => {
+    const entrypoint = path.join(stagedRoot, "src", "index.js");
+    const child = spawn(process.execPath, [entrypoint], {
+      cwd: stagedRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let shutdownExpected = false;
+    const closePromise = new Promise((innerResolve) => {
+      child.once("close", (code, signal) => {
+        innerResolve({ code, signal });
+      });
+    });
+
+    const finish = (callback) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      callback();
+    };
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      finish(() => reject(error));
+    });
+
+    child.on("close", (code) => {
+      if (settled || shutdownExpected) {
+        return;
+      }
+
+      finish(() =>
+        reject(
+          new Error(`${process.execPath} ${entrypoint} exited early with code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`),
+        ),
+      );
+    });
+
+    void (async () => {
+      try {
+        const hostStatus = await waitForJson(`http://127.0.0.1:${env.SERVICE_LASSO_APP_WEB_PORT}/api/host-status`);
+        const runtimeHealth = await waitForJson(`http://127.0.0.1:${env.SERVICE_LASSO_API_PORT}/api/health`);
+
+        shutdownExpected = true;
+        child.kill("SIGINT");
+        const { code, signal } = await closePromise;
+
+        finish(() => {
+          if (code !== 0 && signal !== "SIGINT" && signal !== "SIGTERM") {
+            reject(
+              new Error(
+                `${process.execPath} ${entrypoint} exited with code ${code} and signal ${signal}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+              ),
+            );
+            return;
+          }
+
+          resolve({
+            stdout,
+            stderr,
+            hostStatus,
+            runtimeHealth,
+          });
+        });
+      } catch (error) {
+        shutdownExpected = true;
+        child.kill("SIGTERM");
+        finish(() => reject(error));
+      }
+    })();
+  });
 }
 
 export async function stageReleaseArtifact({ repoRoot, outputRoot = path.join(repoRoot, "artifacts"), version } = {}) {
@@ -171,9 +384,16 @@ export async function verifyStagedArtifact({ repoRoot, artifactRoot, archivePath
 
   const packageJson = await readRootPackageJson(repoRoot);
   const expectedNeedle = packageJson.name.split("/").at(-1);
-  const result = await runCommand(process.execPath, [path.join(stagedRoot, "src", "index.js")], {
-    cwd: stagedRoot,
-    env: process.env,
+  const fixtures = await createVerificationSiblingFixtures(stagedRoot);
+  await installStarterDependencies(stagedRoot, repoRoot);
+  const result = await smokeStarterHost(stagedRoot, {
+    ...process.env,
+    SERVICE_LASSO_APP_WEB_PORT: "19120",
+    SERVICE_LASSO_API_PORT: "18192",
+    SERVICE_LASSO_APP_WEB_ADMIN_DIST_ROOT: fixtures.adminDistRoot,
+    SERVICE_LASSO_APP_WEB_ECHO_SERVICE_ROOT: fixtures.echoServiceRoot,
+    SERVICE_LASSO_SERVICES_ROOT: fixtures.servicesRoot,
+    SERVICE_LASSO_WORKSPACE_ROOT: path.join(stagedRoot, ".workspace", "runtime"),
   });
 
   if (!result.stdout.includes(expectedNeedle)) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function resolveWebConfig(options = {}) {
+  const rootDir = options.repoRoot ?? repoRoot;
+  const siblingRoot = options.siblingRoot ?? path.resolve(rootDir, "..");
+  const hostPort = options.hostPort ?? Number(process.env.SERVICE_LASSO_APP_WEB_PORT ?? 19120);
+  const runtimePort = options.runtimePort ?? Number(process.env.SERVICE_LASSO_API_PORT ?? 18081);
+  const adminDistRoot =
+    options.adminDistRoot ??
+    process.env.SERVICE_LASSO_APP_WEB_ADMIN_DIST_ROOT ??
+    path.join(siblingRoot, "lasso-@serviceadmin", "dist");
+  const workspaceBaseRoot =
+    options.workspaceBaseRoot ??
+    process.env.SERVICE_LASSO_APP_WEB_WORKSPACE_BASE_ROOT ??
+    path.join(rootDir, ".workspace");
+  const workspaceRoot =
+    options.workspaceRoot ??
+    process.env.SERVICE_LASSO_WORKSPACE_ROOT ??
+    path.join(workspaceBaseRoot, "runtime");
+  const servicesRoot =
+    options.servicesRoot ??
+    process.env.SERVICE_LASSO_SERVICES_ROOT ??
+    path.join(workspaceBaseRoot, "services");
+  const echoServiceRoot =
+    options.echoServiceRoot ??
+    process.env.SERVICE_LASSO_APP_WEB_ECHO_SERVICE_ROOT ??
+    path.join(siblingRoot, "lasso-echoservice");
+
+  return {
+    repoRoot: rootDir,
+    siblingRoot,
+    workspaceBaseRoot,
+    hostPort,
+    runtimePort,
+    hostUrl: `http://127.0.0.1:${hostPort}`,
+    runtimeUrl: `http://127.0.0.1:${runtimePort}`,
+    adminDistRoot,
+    adminUrl: `http://127.0.0.1:${hostPort}/admin/`,
+    workspaceRoot,
+    servicesRoot,
+    echoServiceRoot,
+  };
+}
+
+export async function validateWebConfig(config) {
+  await access(path.join(config.echoServiceRoot, "service.json"));
+  await access(path.join(config.adminDistRoot, "index.html"));
+  return config;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,63 @@
-console.log("service-lasso-app-web template scaffold");
-console.log("Next step: replace this placeholder with the actual web host app implementation.");
+import { startApiServer } from "@service-lasso/service-lasso";
+import { once } from "node:events";
+import { resolveWebConfig, validateWebConfig } from "./config.js";
+import { createWebHostServer } from "./server.js";
+import { prepareStarterServicesRoot } from "./services-root.js";
+
+async function closeServer(server) {
+  server.close();
+  await once(server, "close");
+}
+
+async function main() {
+  const config = await validateWebConfig(resolveWebConfig());
+
+  console.log(`[app-web] booting Service Lasso runtime on ${config.runtimeUrl}`);
+  console.log(`[app-web] servicesRoot=${config.servicesRoot}`);
+  console.log(`[app-web] workspaceRoot=${config.workspaceRoot}`);
+
+  const preparedServices = await prepareStarterServicesRoot(config);
+  console.log(`[app-web] prepared Echo Service wrapper at ${preparedServices.wrapperManifestPath}`);
+
+  const runtime = await startApiServer({
+    port: config.runtimePort,
+    servicesRoot: config.servicesRoot,
+    workspaceRoot: config.workspaceRoot,
+  });
+
+  const hostServer = createWebHostServer(config);
+  hostServer.listen(config.hostPort, "127.0.0.1");
+  await once(hostServer, "listening");
+
+  console.log(`[app-web] web shell ready at ${config.hostUrl}`);
+  console.log(`[app-web] admin UI embedded from ${config.adminUrl}`);
+  console.log(`[app-web] runtime API ready at ${runtime.url}`);
+
+  let stopping = false;
+
+  async function shutdown(signal) {
+    if (stopping) {
+      return;
+    }
+
+    stopping = true;
+    console.log(`[app-web] shutting down after ${signal}`);
+
+    await closeServer(hostServer);
+    await runtime.stop();
+  }
+
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT").finally(() => {
+      process.exit(0);
+    });
+  });
+
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM").finally(() => {
+      process.exit(0);
+    });
+  });
+}
+
+await main();

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,272 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { createServer } from "node:http";
+
+const MIME_TYPES = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+function writeJson(response, statusCode, body) {
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(body, null, 2));
+}
+
+function getMimeType(filePath) {
+  return MIME_TYPES[path.extname(filePath).toLowerCase()] ?? "application/octet-stream";
+}
+
+function createShellHtml(config) {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Service Lasso App Web</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4f1e8;
+        --panel: rgba(255, 252, 246, 0.92);
+        --ink: #162427;
+        --muted: #617073;
+        --accent: #cb5f2a;
+        --line: rgba(22, 36, 39, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at top left, rgba(203,95,42,0.16), transparent 34%),
+          radial-gradient(circle at bottom right, rgba(22,36,39,0.08), transparent 28%),
+          linear-gradient(180deg, #fbf8f2 0%, var(--bg) 100%);
+      }
+      main {
+        min-height: 100vh;
+        display: grid;
+        grid-template-columns: minmax(300px, 380px) 1fr;
+        gap: 20px;
+        padding: 24px;
+      }
+      .panel,
+      .frame {
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        background: var(--panel);
+        box-shadow: 0 18px 50px rgba(22,36,39,0.08);
+      }
+      .panel {
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .eyebrow {
+        display: inline-block;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(203,95,42,0.12);
+        color: var(--accent);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      h1 {
+        margin: 0;
+        font-size: 2.1rem;
+        line-height: 1.05;
+      }
+      p, li {
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      .card {
+        padding: 16px;
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        background: rgba(255,255,255,0.55);
+      }
+      .label {
+        display: block;
+        font-size: 0.76rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 8px;
+      }
+      code {
+        display: block;
+        overflow-wrap: anywhere;
+        padding: 8px 10px;
+        border-radius: 10px;
+        background: #efe6d8;
+        font-family: "IBM Plex Mono", "Consolas", monospace;
+        font-size: 0.9rem;
+        color: #28363a;
+      }
+      .links {
+        display: grid;
+        gap: 12px;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .link {
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 14px 16px;
+        background: rgba(255,255,255,0.55);
+      }
+      .link strong {
+        display: block;
+        margin-bottom: 4px;
+      }
+      .frame {
+        overflow: hidden;
+        min-height: calc(100vh - 48px);
+      }
+      iframe {
+        width: 100%;
+        height: 100%;
+        min-height: calc(100vh - 48px);
+        border: 0;
+        background: white;
+      }
+      @media (max-width: 1000px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+        .frame,
+        iframe {
+          min-height: 70vh;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="panel">
+        <span class="eyebrow">App Web Host</span>
+        <h1>Browser-first shell for Service Lasso</h1>
+        <p>
+          This starter owns the outer web shell, embeds Service Admin, and points the runtime at a prepared Echo Service wrapper.
+        </p>
+        <div class="card">
+          <span class="label">Runtime API</span>
+          <code>${config.runtimeUrl}</code>
+        </div>
+        <div class="card">
+          <span class="label">Prepared servicesRoot</span>
+          <code>${config.servicesRoot}</code>
+        </div>
+        <div class="card">
+          <span class="label">Workspace root</span>
+          <code>${config.workspaceRoot}</code>
+        </div>
+        <div class="links">
+          <a class="link" href="/api/host-status">
+            <strong>Host status JSON</strong>
+            <span>Inspect the browser host wiring and runtime roots.</span>
+          </a>
+          <a class="link" href="${config.runtimeUrl}/api/services">
+            <strong>Runtime services API</strong>
+            <span>See the discovered runtime services directly.</span>
+          </a>
+          <a class="link" href="/admin/" target="_blank" rel="noreferrer">
+            <strong>Open Service Admin alone</strong>
+            <span>Launch the embedded admin surface in its own tab.</span>
+          </a>
+        </div>
+      </section>
+      <section class="frame">
+        <iframe title="Service Admin" src="/admin/"></iframe>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
+
+async function serveStaticFile(response, filePath) {
+  response.statusCode = 200;
+  response.setHeader("content-type", getMimeType(filePath));
+  createReadStream(filePath).pipe(response);
+}
+
+async function resolveStaticFile(config, pathname) {
+  const trimmed = pathname.replace(/^\/admin\/?/, "");
+  const candidate = trimmed.length === 0 ? "index.html" : trimmed;
+  const filePath = path.join(config.adminDistRoot, candidate);
+
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.isFile()) {
+      return filePath;
+    }
+  } catch {}
+
+  return path.join(config.adminDistRoot, "index.html");
+}
+
+export function createHostStatus(config) {
+  return {
+    app: "@service-lasso/service-lasso-app-web",
+    hostUrl: config.hostUrl,
+    runtimeUrl: config.runtimeUrl,
+    adminUrl: config.adminUrl,
+    servicesRoot: config.servicesRoot,
+    workspaceRoot: config.workspaceRoot,
+    echoServiceRoot: config.echoServiceRoot,
+    adminDistRoot: config.adminDistRoot,
+    notes: [
+      "Host-owned web shell is served at /.",
+      "Service Admin is mounted from the sibling build under /admin/.",
+      "A local wrapper servicesRoot is prepared so only the Echo Service fixture is discovered by default.",
+    ],
+  };
+}
+
+export function createWebHostServer(config) {
+  const shellHtml = createShellHtml(config);
+  const statusBody = createHostStatus(config);
+
+  return createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+
+    if (request.method === "GET" && url.pathname === "/") {
+      response.statusCode = 200;
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.end(shellHtml);
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/host-status") {
+      writeJson(response, 200, statusBody);
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname.startsWith("/admin")) {
+      const filePath = await resolveStaticFile(config, url.pathname);
+      await serveStaticFile(response, filePath);
+      return;
+    }
+
+    response.statusCode = 404;
+    response.setHeader("content-type", "text/plain; charset=utf-8");
+    response.end("not found");
+  });
+}

--- a/src/services-root.js
+++ b/src/services-root.js
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+export async function prepareStarterServicesRoot(config) {
+  const templateManifestPath = path.join(config.echoServiceRoot, "service.json");
+  const wrapperServiceRoot = path.join(config.servicesRoot, "echo-service");
+  const wrapperManifestPath = path.join(wrapperServiceRoot, "service.json");
+  const wrapperEntrypointPath = path.join(wrapperServiceRoot, "run-echo-service.mjs");
+  const templateManifest = JSON.parse(await readFile(templateManifestPath, "utf8"));
+
+  const wrapperScript = [
+    'import { spawn } from "node:child_process";',
+    "",
+    `const echoServiceRoot = ${JSON.stringify(config.echoServiceRoot)};`,
+    'const child = spawn("go", ["run", "."], {',
+    "  cwd: echoServiceRoot,",
+    "  env: process.env,",
+    '  stdio: "inherit",',
+    "});",
+    "",
+    'for (const signal of ["SIGINT", "SIGTERM"]) {',
+    "  process.on(signal, () => {",
+    "    child.kill(signal);",
+    "  });",
+    "}",
+    "",
+    'child.on("exit", (code, signal) => {',
+    "  if (signal) {",
+    "    process.exit(1);",
+    "    return;",
+    "  }",
+    "  process.exit(code ?? 0);",
+    "});",
+    "",
+  ].join("\n");
+
+  const wrapperManifest = {
+    ...templateManifest,
+    description: `${templateManifest.description} Wrapped by service-lasso-app-web for local host discovery.`,
+    executable: "node",
+    args: ["./run-echo-service.mjs"],
+  };
+
+  await mkdir(wrapperServiceRoot, { recursive: true });
+  await writeFile(wrapperEntrypointPath, `${wrapperScript}\n`, "utf8");
+  await writeFile(wrapperManifestPath, `${JSON.stringify(wrapperManifest, null, 2)}\n`, "utf8");
+
+  return {
+    wrapperServiceRoot,
+    wrapperManifestPath,
+    wrapperEntrypointPath,
+  };
+}

--- a/tests/host.test.js
+++ b/tests/host.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { resolveWebConfig, validateWebConfig } from "../src/config.js";
+import { createHostStatus, createWebHostServer } from "../src/server.js";
+
+async function createFixtureRoots() {
+  const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-web-"));
+  const siblingRoot = path.join(root, "siblings");
+  const adminDistRoot = path.join(siblingRoot, "lasso-@serviceadmin", "dist");
+  const echoServiceRoot = path.join(siblingRoot, "lasso-echoservice");
+
+  await mkdir(adminDistRoot, { recursive: true });
+  await mkdir(echoServiceRoot, { recursive: true });
+  await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>admin</title>", "utf8");
+  await writeFile(path.join(adminDistRoot, "asset.js"), "console.log('admin asset');", "utf8");
+  await writeFile(path.join(echoServiceRoot, "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
+
+  return {
+    root,
+    siblingRoot,
+    adminDistRoot,
+    echoServiceRoot,
+  };
+}
+
+test("web config resolves deterministic sibling repo paths", async () => {
+  const fixture = await createFixtureRoots();
+
+  try {
+    const config = resolveWebConfig({
+      repoRoot: path.join(fixture.root, "service-lasso-app-web"),
+      siblingRoot: fixture.siblingRoot,
+      hostPort: 19120,
+      runtimePort: 18192,
+    });
+
+    assert.equal(config.hostUrl, "http://127.0.0.1:19120");
+    assert.equal(config.runtimeUrl, "http://127.0.0.1:18192");
+    assert.equal(config.adminDistRoot, fixture.adminDistRoot);
+    assert.equal(config.echoServiceRoot, fixture.echoServiceRoot);
+
+    await assert.doesNotReject(() => validateWebConfig(config));
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("web host serves shell, host status, and mounted admin assets", async () => {
+  const fixture = await createFixtureRoots();
+
+  try {
+    const config = await validateWebConfig(
+      resolveWebConfig({
+        repoRoot: path.join(fixture.root, "service-lasso-app-web"),
+        siblingRoot: fixture.siblingRoot,
+        hostPort: 0,
+        runtimePort: 18192,
+      }),
+    );
+    const status = createHostStatus(config);
+    assert.equal(status.app, "@service-lasso/service-lasso-app-web");
+    assert.equal(status.echoServiceRoot, fixture.echoServiceRoot);
+
+    const server = createWebHostServer(config);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const shellResponse = await fetch(`${baseUrl}/`);
+      assert.equal(shellResponse.status, 200);
+      const shellHtml = await shellResponse.text();
+      assert.match(shellHtml, /Browser-first shell for Service Lasso/);
+      assert.match(shellHtml, /<iframe title="Service Admin" src="\/admin\/"><\/iframe>/);
+
+      const statusResponse = await fetch(`${baseUrl}/api/host-status`);
+      assert.equal(statusResponse.status, 200);
+      const statusBody = await statusResponse.json();
+      assert.equal(statusBody.runtimeUrl, config.runtimeUrl);
+      assert.equal(statusBody.adminDistRoot, fixture.adminDistRoot);
+
+      const assetResponse = await fetch(`${baseUrl}/admin/asset.js`);
+      assert.equal(assetResponse.status, 200);
+      assert.match(await assetResponse.text(), /admin asset/);
+
+      const spaResponse = await fetch(`${baseUrl}/admin/missing/route`);
+      assert.equal(spaResponse.status, 200);
+      assert.match(await spaResponse.text(), /<title>admin<\/title>/);
+    } finally {
+      server.close();
+      await once(server, "close");
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});

--- a/tests/services-root.test.js
+++ b/tests/services-root.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { prepareStarterServicesRoot } from "../src/services-root.js";
+
+test("web starter servicesRoot is prepared with an echo-service wrapper manifest", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-web-services-"));
+  const echoServiceRoot = path.join(root, "lasso-echoservice");
+  const servicesRoot = path.join(root, ".workspace", "services");
+
+  try {
+    await mkdir(echoServiceRoot, { recursive: true });
+    await writeFile(
+      path.join(echoServiceRoot, "service.json"),
+      `${JSON.stringify(
+        {
+          id: "echo-service",
+          name: "Echo Service",
+          description: "Harness",
+          version: "0.0.0",
+          enabled: true,
+          executable: "go",
+          args: ["run", "."],
+          healthcheck: {
+            type: "process",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const prepared = await prepareStarterServicesRoot({
+      echoServiceRoot,
+      servicesRoot,
+    });
+
+    assert.equal(prepared.wrapperServiceRoot, path.join(servicesRoot, "echo-service"));
+    const wrapperManifest = JSON.parse(await readFile(prepared.wrapperManifestPath, "utf8"));
+    assert.equal(wrapperManifest.id, "echo-service");
+    assert.equal(wrapperManifest.executable, "node");
+    assert.deepEqual(wrapperManifest.args, ["./run-echo-service.mjs"]);
+    assert.match(wrapperManifest.description, /Wrapped by service-lasso-app-web/);
+    const wrapperEntrypoint = await readFile(prepared.wrapperEntrypointPath, "utf8");
+    assert.match(wrapperEntrypoint, /spawn\("go", \["run", "\."\]/);
+    assert.match(wrapperEntrypoint, new RegExp(JSON.stringify(echoServiceRoot).slice(1, -1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- replace the placeholder starter with a browser-first web host around the published Service Lasso runtime
- embed the sibling Service Admin build and prepare a local Echo Service wrapper servicesRoot
- add route/release verification coverage and GitHub Packages-aware CI/release wiring

## Verification
- npm test
- npm run release:verify
- local workspace smoke against sibling lasso-echoservice and lasso-@serviceadmin
