### PR TITLE
Release latest on main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - "v*"
 
@@ -60,11 +62,15 @@ jobs:
           path: artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz
 
       - name: Create or update GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            TAG_NAME="latest"
+            git tag -f "$TAG_NAME" "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG_NAME" --force
+          fi
           ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
           gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Starter-template source artifact release."
           gh release upload "$TAG_NAME" "$ARCHIVE_PATH" --clobber

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Current pipelines:
   - runs on pushes to `main` and on pull requests
   - installs dependencies and runs `npm test`
 - `Release`
-  - runs on version tags like `v0.1.0` or by manual dispatch
-  - runs tests, verifies the artifact, uploads the packaged files, and creates or updates the tagged GitHub release
+  - runs on pushes to `main`, version tags, or by manual dispatch
+  - runs tests, verifies the artifact, uploads the packaged files, and creates or updates the rolling `latest` release on `main`
 
 Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -25,7 +25,7 @@ The artifact proves:
 - the template repo can be packaged repeatably
 - the packaged template contains the documented starter files
 - the staged starter can install the core runtime package and still run `npm start`
-- GitHub Actions can upload the artifact and attach the archive to tagged releases
+- GitHub Actions can upload the artifact and attach the archive to the rolling `latest` release on `main`
 
 ## Private package note
 


### PR DESCRIPTION
## Summary
- make the release workflow run on pushes to main as well as tags
- document the rolling latest release behavior

## Verification
- npm test
- npm run release:verify