### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -45,13 +45,13 @@ jobs:
           echo "artifact_name=$NAME-$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Upload staged artifact folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.release_version.outputs.artifact_name }}
           path: artifacts/${{ steps.release_version.outputs.artifact_name }}
 
       - name: Upload packaged archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.release_version.outputs.artifact_name }}-archive
           path: artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz


### PR DESCRIPTION
## Summary
- upgrade checkout to the Node 24-compatible major
- upgrade setup-node to the Node 24-compatible major
- upgrade upload-artifact to the Node 24-compatible major where used

## Verification
- npm test