### PR TITLE
Track starter services in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Current implementation:
 - published `@service-lasso/service-lasso` runtime package consumption
 - host-owned landing shell at `/`
 - embedded sibling `lasso-@serviceadmin` build at `/admin/`
-- prepared local `servicesRoot` wrapper for sibling `lasso-echoservice`
+- tracked repo-owned `services/` definitions for Echo Service and Service Admin
+- prepared local `servicesRoot` copied from tracked service manifests plus a generated Echo Service runner
 
 Current local start command:
 - `npm start`

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -13,6 +13,7 @@ const CANDIDATE_RELEASE_PATHS = [
   "package-lock.json",
   "src",
   "src-tauri",
+  "services",
   "docs",
   "scripts",
   "tests",

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -1,0 +1,34 @@
+{
+  "id": "echo-service",
+  "name": "Echo Service",
+  "description": "Release-backed Echo Service harness for the app-web starter.",
+  "version": "0.3.0",
+  "enabled": true,
+  "executable": "node",
+  "args": ["./run-echo-service.mjs"],
+  "env": {
+    "ECHO_MESSAGE": "hello from service-lasso-app-web",
+    "ECHO_PORT": "4010",
+    "ECHO_HTTP_HEALTH_PORT": "4011",
+    "ECHO_TCP_PORT": "4012",
+    "ECHO_LOG_PATH": "./runtime/echo.log",
+    "ECHO_STATE_PATH": "./runtime/state.json",
+    "ECHO_DB_PATH": "./runtime/echo.sqlite",
+    "SERVICE_LASSO_GLOBAL_ENV_JSON": "{\"ECHO_ENV_CHANNEL\":\"app-web\"}"
+  },
+  "urls": [
+    {
+      "label": "ui",
+      "url": "http://127.0.0.1:4010/",
+      "kind": "local"
+    },
+    {
+      "label": "service",
+      "url": "http://127.0.0.1:4010/health",
+      "kind": "local"
+    }
+  ],
+  "healthcheck": {
+    "type": "process"
+  }
+}

--- a/services/service-admin/service.json
+++ b/services/service-admin/service.json
@@ -1,0 +1,14 @@
+{
+  "id": "service-admin",
+  "name": "Service Admin",
+  "description": "Embedded Service Admin UI surfaced by the app-web starter host.",
+  "version": "0.1.0",
+  "enabled": false,
+  "urls": [
+    {
+      "label": "ui",
+      "url": "http://127.0.0.1:19120/admin/",
+      "kind": "local"
+    }
+  ]
+}

--- a/src/config.js
+++ b/src/config.js
@@ -25,9 +25,13 @@ export function resolveWebConfig(options = {}) {
     options.servicesRoot ??
     process.env.SERVICE_LASSO_SERVICES_ROOT ??
     path.join(workspaceBaseRoot, "services");
-  const echoServiceRoot =
-    options.echoServiceRoot ??
-    process.env.SERVICE_LASSO_APP_WEB_ECHO_SERVICE_ROOT ??
+  const sourceServicesRoot =
+    options.sourceServicesRoot ??
+    process.env.SERVICE_LASSO_APP_WEB_SOURCE_SERVICES_ROOT ??
+    path.join(rootDir, "services");
+  const echoServiceRepoRoot =
+    options.echoServiceRepoRoot ??
+    process.env.SERVICE_LASSO_APP_WEB_ECHO_SERVICE_REPO_ROOT ??
     path.join(siblingRoot, "lasso-echoservice");
 
   return {
@@ -42,12 +46,15 @@ export function resolveWebConfig(options = {}) {
     adminUrl: `http://127.0.0.1:${hostPort}/admin/`,
     workspaceRoot,
     servicesRoot,
-    echoServiceRoot,
+    sourceServicesRoot,
+    echoServiceRepoRoot,
   };
 }
 
 export async function validateWebConfig(config) {
-  await access(path.join(config.echoServiceRoot, "service.json"));
+  await access(path.join(config.sourceServicesRoot, "echo-service", "service.json"));
+  await access(path.join(config.sourceServicesRoot, "service-admin", "service.json"));
+  await access(path.join(config.echoServiceRepoRoot, "service.json"));
   await access(path.join(config.adminDistRoot, "index.html"));
   return config;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -229,13 +229,15 @@ export function createHostStatus(config) {
     runtimeUrl: config.runtimeUrl,
     adminUrl: config.adminUrl,
     servicesRoot: config.servicesRoot,
+    sourceServicesRoot: config.sourceServicesRoot,
     workspaceRoot: config.workspaceRoot,
-    echoServiceRoot: config.echoServiceRoot,
+    echoServiceRepoRoot: config.echoServiceRepoRoot,
     adminDistRoot: config.adminDistRoot,
     notes: [
       "Host-owned web shell is served at /.",
       "Service Admin is mounted from the sibling build under /admin/.",
-      "A local wrapper servicesRoot is prepared so only the Echo Service fixture is discovered by default.",
+      "Tracked services/ definitions are copied into the prepared servicesRoot before runtime startup.",
+      "A local Echo Service runner is generated into the prepared servicesRoot.",
     ],
   };
 }

--- a/src/services-root.js
+++ b/src/services-root.js
@@ -1,17 +1,15 @@
 import path from "node:path";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { cp, mkdir, writeFile } from "node:fs/promises";
 
 export async function prepareStarterServicesRoot(config) {
-  const templateManifestPath = path.join(config.echoServiceRoot, "service.json");
-  const wrapperServiceRoot = path.join(config.servicesRoot, "echo-service");
-  const wrapperManifestPath = path.join(wrapperServiceRoot, "service.json");
+  const echoServiceRoot = path.join(config.servicesRoot, "echo-service");
+  const wrapperServiceRoot = echoServiceRoot;
   const wrapperEntrypointPath = path.join(wrapperServiceRoot, "run-echo-service.mjs");
-  const templateManifest = JSON.parse(await readFile(templateManifestPath, "utf8"));
 
   const wrapperScript = [
     'import { spawn } from "node:child_process";',
     "",
-    `const echoServiceRoot = ${JSON.stringify(config.echoServiceRoot)};`,
+    `const echoServiceRoot = ${JSON.stringify(config.echoServiceRepoRoot)};`,
     'const child = spawn("go", ["run", "."], {',
     "  cwd: echoServiceRoot,",
     "  env: process.env,",
@@ -34,20 +32,14 @@ export async function prepareStarterServicesRoot(config) {
     "",
   ].join("\n");
 
-  const wrapperManifest = {
-    ...templateManifest,
-    description: `${templateManifest.description} Wrapped by service-lasso-app-web for local host discovery.`,
-    executable: "node",
-    args: ["./run-echo-service.mjs"],
-  };
-
+  await cp(config.sourceServicesRoot, config.servicesRoot, { recursive: true, force: true });
   await mkdir(wrapperServiceRoot, { recursive: true });
   await writeFile(wrapperEntrypointPath, `${wrapperScript}\n`, "utf8");
-  await writeFile(wrapperManifestPath, `${JSON.stringify(wrapperManifest, null, 2)}\n`, "utf8");
 
   return {
-    wrapperServiceRoot,
-    wrapperManifestPath,
+    servicesRoot: config.servicesRoot,
+    echoServiceRoot: wrapperServiceRoot,
+    serviceAdminRoot: path.join(config.servicesRoot, "service-admin"),
     wrapperEntrypointPath,
   };
 }

--- a/tests/host.test.js
+++ b/tests/host.test.js
@@ -11,19 +11,25 @@ async function createFixtureRoots() {
   const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-web-"));
   const siblingRoot = path.join(root, "siblings");
   const adminDistRoot = path.join(siblingRoot, "lasso-@serviceadmin", "dist");
-  const echoServiceRoot = path.join(siblingRoot, "lasso-echoservice");
+  const echoServiceRepoRoot = path.join(siblingRoot, "lasso-echoservice");
+  const sourceServicesRoot = path.join(root, "service-lasso-app-web", "services");
 
   await mkdir(adminDistRoot, { recursive: true });
-  await mkdir(echoServiceRoot, { recursive: true });
+  await mkdir(echoServiceRepoRoot, { recursive: true });
+  await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
+  await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
   await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>admin</title>", "utf8");
   await writeFile(path.join(adminDistRoot, "asset.js"), "console.log('admin asset');", "utf8");
-  await writeFile(path.join(echoServiceRoot, "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
+  await writeFile(path.join(echoServiceRepoRoot, "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
+  await writeFile(path.join(sourceServicesRoot, "echo-service", "service.json"), "{\n  \"id\": \"echo-service\"\n}\n", "utf8");
+  await writeFile(path.join(sourceServicesRoot, "service-admin", "service.json"), "{\n  \"id\": \"service-admin\"\n}\n", "utf8");
 
   return {
     root,
     siblingRoot,
     adminDistRoot,
-    echoServiceRoot,
+    echoServiceRepoRoot,
+    sourceServicesRoot,
   };
 }
 
@@ -41,7 +47,8 @@ test("web config resolves deterministic sibling repo paths", async () => {
     assert.equal(config.hostUrl, "http://127.0.0.1:19120");
     assert.equal(config.runtimeUrl, "http://127.0.0.1:18192");
     assert.equal(config.adminDistRoot, fixture.adminDistRoot);
-    assert.equal(config.echoServiceRoot, fixture.echoServiceRoot);
+    assert.equal(config.sourceServicesRoot, fixture.sourceServicesRoot);
+    assert.equal(config.echoServiceRepoRoot, fixture.echoServiceRepoRoot);
 
     await assert.doesNotReject(() => validateWebConfig(config));
   } finally {
@@ -63,7 +70,8 @@ test("web host serves shell, host status, and mounted admin assets", async () =>
     );
     const status = createHostStatus(config);
     assert.equal(status.app, "@service-lasso/service-lasso-app-web");
-    assert.equal(status.echoServiceRoot, fixture.echoServiceRoot);
+    assert.equal(status.sourceServicesRoot, fixture.sourceServicesRoot);
+    assert.equal(status.echoServiceRepoRoot, fixture.echoServiceRepoRoot);
 
     const server = createWebHostServer(config);
     server.listen(0, "127.0.0.1");
@@ -85,6 +93,7 @@ test("web host serves shell, host status, and mounted admin assets", async () =>
       const statusBody = await statusResponse.json();
       assert.equal(statusBody.runtimeUrl, config.runtimeUrl);
       assert.equal(statusBody.adminDistRoot, fixture.adminDistRoot);
+      assert.equal(statusBody.sourceServicesRoot, fixture.sourceServicesRoot);
 
       const assetResponse = await fetch(`${baseUrl}/admin/asset.js`);
       assert.equal(assetResponse.status, 200);

--- a/tests/services-root.test.js
+++ b/tests/services-root.test.js
@@ -7,13 +7,16 @@ import { prepareStarterServicesRoot } from "../src/services-root.js";
 
 test("web starter servicesRoot is prepared with an echo-service wrapper manifest", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "service-lasso-app-web-services-"));
-  const echoServiceRoot = path.join(root, "lasso-echoservice");
+  const echoServiceRepoRoot = path.join(root, "lasso-echoservice");
+  const sourceServicesRoot = path.join(root, "services-template");
   const servicesRoot = path.join(root, ".workspace", "services");
 
   try {
-    await mkdir(echoServiceRoot, { recursive: true });
+    await mkdir(echoServiceRepoRoot, { recursive: true });
+    await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
+    await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
     await writeFile(
-      path.join(echoServiceRoot, "service.json"),
+      path.join(echoServiceRepoRoot, "service.json"),
       `${JSON.stringify(
         {
           id: "echo-service",
@@ -32,21 +35,49 @@ test("web starter servicesRoot is prepared with an echo-service wrapper manifest
       )}\n`,
       "utf8",
     );
+    await writeFile(
+      path.join(sourceServicesRoot, "echo-service", "service.json"),
+      `${JSON.stringify(
+        {
+          id: "echo-service",
+          name: "Echo Service",
+          description: "Tracked service definition",
+          version: "0.0.0",
+          enabled: true,
+          executable: "node",
+          args: ["./run-echo-service.mjs"],
+          healthcheck: {
+            type: "process",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(sourceServicesRoot, "service-admin", "service.json"),
+      "{\n  \"id\": \"service-admin\",\n  \"enabled\": false\n}\n",
+      "utf8",
+    );
 
     const prepared = await prepareStarterServicesRoot({
-      echoServiceRoot,
+      sourceServicesRoot,
+      echoServiceRepoRoot,
       servicesRoot,
     });
 
-    assert.equal(prepared.wrapperServiceRoot, path.join(servicesRoot, "echo-service"));
-    const wrapperManifest = JSON.parse(await readFile(prepared.wrapperManifestPath, "utf8"));
+    assert.equal(prepared.echoServiceRoot, path.join(servicesRoot, "echo-service"));
+    assert.equal(prepared.serviceAdminRoot, path.join(servicesRoot, "service-admin"));
+    const wrapperManifest = JSON.parse(await readFile(path.join(servicesRoot, "echo-service", "service.json"), "utf8"));
     assert.equal(wrapperManifest.id, "echo-service");
     assert.equal(wrapperManifest.executable, "node");
     assert.deepEqual(wrapperManifest.args, ["./run-echo-service.mjs"]);
-    assert.match(wrapperManifest.description, /Wrapped by service-lasso-app-web/);
+    const adminManifest = JSON.parse(await readFile(path.join(servicesRoot, "service-admin", "service.json"), "utf8"));
+    assert.equal(adminManifest.id, "service-admin");
     const wrapperEntrypoint = await readFile(prepared.wrapperEntrypointPath, "utf8");
     assert.match(wrapperEntrypoint, /spawn\("go", \["run", "\."\]/);
-    assert.match(wrapperEntrypoint, new RegExp(JSON.stringify(echoServiceRoot).slice(1, -1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.match(wrapperEntrypoint, new RegExp(JSON.stringify(echoServiceRepoRoot).slice(1, -1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add tracked services/echo-service and services/service-admin manifests to the starter repo
- prepare the runtime servicesRoot from the tracked services directory
- keep the generated Echo Service runner in workspace state rather than source manifests

## Verification
- npm test
- npm run release:verify