### PR TITLE
Align web release workflow with timestamped version pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
 
 jobs:
   release:
@@ -18,6 +16,16 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v5
+
+      - name: Compute release version
+        id: release_version
+        shell: bash
+        run: |
+          short_sha="${GITHUB_SHA::7}"
+          version="$(date -u +%Y.%-m.%-d)-${short_sha}"
+          name="$(node -p "require('./package.json').name.split('/').pop()")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${name}-${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node
         uses: actions/setup-node@v5
@@ -36,13 +44,7 @@ jobs:
         run: npm run release:verify
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
-
-      - name: Read release version
-        id: release_version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          NAME=$(node -p "require('./package.json').name.split('/').pop()")
-          echo "artifact_name=$NAME-$VERSION" >> "$GITHUB_OUTPUT"
+          SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
 
       - name: Upload staged artifact folder
         uses: actions/upload-artifact@v6
@@ -59,13 +61,9 @@ jobs:
       - name: Create or update GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SERVICE_LASSO_RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
         run: |
-          TAG_NAME="${GITHUB_REF_NAME}"
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            TAG_NAME="latest"
-            git tag -f "$TAG_NAME" "$GITHUB_SHA"
-            git push origin "refs/tags/$TAG_NAME" --force
-          fi
+          TAG_NAME="${SERVICE_LASSO_RELEASE_VERSION}"
           ARCHIVE_PATH="artifacts/${{ steps.release_version.outputs.artifact_name }}.tar.gz"
           gh release view "$TAG_NAME" >/dev/null 2>&1 || gh release create "$TAG_NAME" --title "$TAG_NAME" --notes "Starter-template source artifact release."
           gh release upload "$TAG_NAME" "$ARCHIVE_PATH" --clobber

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Current pipelines:
   - runs on pushes to `main` and on pull requests
   - installs dependencies and runs `npm test`
 - `Release`
-  - runs on pushes to `main`, version tags, or by manual dispatch
-  - runs tests, verifies the artifact, uploads the packaged files, and creates or updates the rolling `latest` release on `main`
+  - runs on pushes to `main` or by manual dispatch
+  - runs tests, verifies the artifact, uploads the packaged files, and creates a timestamped `yyyy.m.d-<shortsha>` release from `main`
 
 Current shipped artifact contents are documented in:
 - `docs/release-artifact.md`

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -25,7 +25,7 @@ The artifact proves:
 - the template repo can be packaged repeatably
 - the packaged template contains the documented starter files
 - the staged starter can install the core runtime package and still run `npm start`
-- GitHub Actions can upload the artifact and attach the archive to the rolling `latest` release on `main`
+- GitHub Actions can upload the artifact and attach the archive to a timestamped `yyyy.m.d-<shortsha>` release on `main`
 
 ## Private package note
 
@@ -50,6 +50,16 @@ Stage and verify the artifact:
 ```bash
 npm run release:verify
 ```
+
+## Release version pattern
+
+Releases from `main` use the project timestamped pattern:
+
+- `yyyy.m.d-<shortsha>`
+
+Example:
+
+- `2026.4.23-abcdef1`
 
 ## Honest current label
 

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -24,6 +24,10 @@ export async function readRootPackageJson(repoRoot) {
 }
 
 export async function getReleaseVersion(repoRoot) {
+  if (process.env.SERVICE_LASSO_RELEASE_VERSION) {
+    return process.env.SERVICE_LASSO_RELEASE_VERSION;
+  }
+
   const packageJson = await readRootPackageJson(repoRoot);
   return packageJson.version;
 }

--- a/tests/release-artifact.test.js
+++ b/tests/release-artifact.test.js
@@ -37,3 +37,28 @@ test("starter release artifact can be staged and verified", async () => {
     await rm(outputRoot, { recursive: true, force: true });
   }
 });
+
+test("starter release artifact respects SERVICE_LASSO_RELEASE_VERSION when provided", async () => {
+  const outputRoot = await createTemporaryOutputRoot();
+  const previousVersion = process.env.SERVICE_LASSO_RELEASE_VERSION;
+  process.env.SERVICE_LASSO_RELEASE_VERSION = "2026.4.23-abcdef1";
+
+  try {
+    const packageJson = await readRootPackageJson(repoRoot);
+    const packageSuffix = packageJson.name.split("/").at(-1);
+    const staged = await stageReleaseArtifact({
+      repoRoot,
+      outputRoot,
+    });
+
+    assert.equal(staged.artifactName, `${packageSuffix}-2026.4.23-abcdef1`);
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.SERVICE_LASSO_RELEASE_VERSION;
+    } else {
+      process.env.SERVICE_LASSO_RELEASE_VERSION = previousVersion;
+    }
+
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- stop publishing the app-web release to a rolling latest tag
- use the established yyyy.m.d-<shortsha> version pattern on main
- make the artifact scripts honor SERVICE_LASSO_RELEASE_VERSION and cover it in tests

## Verification
- npm test
- SERVICE_LASSO_RELEASE_VERSION=2026.4.23-abcdef1 npm run release:verify
- git diff --check