### PR TITLE
ISS-050: Add web host service widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current implementation:
 - browser-first host entrypoint under `src/index.js`
 - published `@service-lasso/service-lasso` runtime package consumption
 - host-owned landing shell at `/`
+- host-owned services widget that reads the runtime API through `/api/runtime-services`
 - embedded sibling `lasso-@serviceadmin` build at `/admin/`
 - tracked repo-owned `services/` definitions for Echo Service and Service Admin
 - manifest-owned Echo Service archive metadata under `services/echo-service/service.json`

--- a/docs/minimal-poc.md
+++ b/docs/minimal-poc.md
@@ -18,6 +18,7 @@ The POC should:
 - point that runtime at a `servicesRoot` containing Echo Service
 - show a host-owned landing or shell view first
 - point the browser app at the runtime API
+- render a host-owned services widget that fetches Service Lasso runtime data
 - surface `lasso-@serviceadmin` inside the web app host
 - show Echo Service in the admin UI and allow at least:
   - services list
@@ -45,11 +46,12 @@ The POC should:
 1. Start the runtime host for the web app.
 2. Open the browser app.
 3. See host-owned output from the web shell before or alongside the admin surface.
-4. See the embedded or proxied Service Admin UI.
-5. See Echo Service listed in services.
-6. Open Echo Service detail.
-7. Start/stop Echo Service from the UI.
-8. View logs and health for Echo Service.
+4. See the host-owned service widget list services from the runtime API.
+5. See the embedded or proxied Service Admin UI.
+6. See Echo Service listed in services.
+7. Open Echo Service detail.
+8. Start/stop Echo Service from the UI.
+9. View logs and health for Echo Service.
 
 ## POC deliverables
 
@@ -65,6 +67,7 @@ The POC should:
 This bounded POC is now implemented in-repo:
 - `npm start` boots the published `@service-lasso/service-lasso` runtime
 - the host serves its own browser shell at `/`
+- the host shell includes a bounded services widget backed by `/api/runtime-services`
 - the host embeds the sibling built `lasso-@serviceadmin` app at `/admin/`
 - the host prepares a local `servicesRoot` from the tracked repo `services/` inventory so `echo-service` is discovered from manifest-owned archive metadata
 
@@ -78,4 +81,4 @@ This POC does not need:
 
 It only needs to prove:
 
-**a web host can present Service Admin against a real Service Lasso runtime managing Echo Service**
+**a web host can present host-owned runtime API output plus Service Admin against a real Service Lasso runtime managing Echo Service**

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -95,6 +95,7 @@ The release now proves:
 - the repo owns explicit tracked service metadata under `services/`
 - the browser-first host can be packaged repeatably
 - the runnable artifact can boot Service Lasso and Service Admin without sibling-repo checkout tricks
+- the host shell includes a bounded service listing widget backed by the runtime API
 - Echo Service acquisition now depends on manifest-owned archive metadata instead of a generated local wrapper
 - bootstrap-download mode installs the service payload before first use
 - preloaded mode installs from an already-shipped archive without a first-run download

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -104,7 +104,9 @@ The release now proves:
 ## Private package note
 
 This starter depends on the published private core package:
-- `@service-lasso/service-lasso`
+- `@service-lasso/service-lasso@latest`
+
+The `latest` dist-tag is intentional so starter artifacts consume the current manifest-owned install/acquire behavior published by the core repo.
 
 For local or CI installs from GitHub Packages, provide a token with package read access through:
 - `NODE_AUTH_TOKEN`

--- a/docs/task-list.md
+++ b/docs/task-list.md
@@ -33,7 +33,10 @@ Turn the starter into the smallest real browser-first host that:
 7. Add direct tests for config resolution, host routes, and wrapper materialization
    status: done
 
-8. Prove local start behavior against the current workspace
+8. Add a bounded host-owned service listing widget backed by the runtime API
+   status: done
+
+9. Prove local start behavior against the current workspace
    status: done
 
 ## Honest current scope
@@ -48,6 +51,7 @@ It only proves:
 
 - `npm test`
 - `npm run release:verify`
+- direct host test for `/api/runtime-services` proxy and widget markup
 - local smoke:
   - web shell on `http://127.0.0.1:19120`
   - runtime API on `http://127.0.0.1:18081`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "release:verify": "node scripts/release-verify.mjs"
   },
   "dependencies": {
-    "@service-lasso/service-lasso": "^0.1.0"
+    "@service-lasso/service-lasso": "latest"
   }
 }

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -365,6 +365,22 @@ async function createVerificationAdminDist(rootDir) {
   return adminDistRoot;
 }
 
+async function resolveReleaseAdminDist(repoRoot, outputRoot, sourceAdminDistRoot) {
+  const candidates = [
+    sourceAdminDistRoot,
+    process.env.SERVICE_LASSO_APP_WEB_ADMIN_DIST_ROOT,
+    path.resolve(repoRoot, "..", "lasso-@serviceadmin", "dist"),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (existsSync(path.join(candidate, "index.html"))) {
+      return candidate;
+    }
+  }
+
+  return createVerificationAdminDist(outputRoot);
+}
+
 async function createVerificationReleaseFixture(rootDir, assetNameOverride = null) {
   const fixtureRoot = path.join(rootDir, ".verify-fixture");
   const workRoot = path.join(fixtureRoot, "work");
@@ -689,12 +705,7 @@ export async function stageReleaseArtifacts({ repoRoot, outputRoot = path.join(r
   const baseName = await getArtifactNameBase(repoRoot, resolvedVersion);
   const sourceFiles = await listExistingPaths(repoRoot, SOURCE_RELEASE_PATHS);
   const runtimeFiles = await listExistingPaths(repoRoot, RUNTIME_RELEASE_PATHS);
-  const resolvedAdminDistRoot =
-    sourceAdminDistRoot ??
-    process.env.SERVICE_LASSO_APP_WEB_ADMIN_DIST_ROOT ??
-    (existsSync(path.resolve(repoRoot, "..", "lasso-@serviceadmin", "dist"))
-      ? path.resolve(repoRoot, "..", "lasso-@serviceadmin", "dist")
-      : null);
+  const resolvedAdminDistRoot = await resolveReleaseAdminDist(repoRoot, outputRoot, sourceAdminDistRoot);
 
   const source = await stageSingleArtifact({
     repoRoot,

--- a/src/server.js
+++ b/src/server.js
@@ -99,6 +99,79 @@ function createShellHtml(config) {
         border: 1px solid var(--line);
         background: rgba(255,255,255,0.55);
       }
+      .service-widget {
+        display: grid;
+        gap: 12px;
+      }
+      .service-widget__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .service-widget__header p {
+        margin: 4px 0 0;
+      }
+      .service-widget__refresh {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 8px 12px;
+        background: #fff8ee;
+        color: var(--ink);
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+      }
+      .service-widget__status {
+        margin: 0;
+        color: var(--muted);
+      }
+      .service-list {
+        display: grid;
+        gap: 10px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .service-row {
+        display: grid;
+        gap: 8px;
+        padding: 12px;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.68);
+      }
+      .service-row__top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 10px;
+      }
+      .service-row__name {
+        font-weight: 800;
+      }
+      .service-row__id,
+      .service-row__detail {
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+      .pill {
+        border-radius: 999px;
+        padding: 4px 8px;
+        background: rgba(22,36,39,0.08);
+        color: var(--ink);
+        font-size: 0.78rem;
+        font-weight: 800;
+        white-space: nowrap;
+      }
+      .pill--healthy {
+        background: rgba(68, 128, 82, 0.16);
+        color: #2f6f3e;
+      }
+      .pill--unhealthy {
+        background: rgba(203, 95, 42, 0.16);
+        color: var(--accent);
+      }
       .label {
         display: block;
         font-size: 0.76rem;
@@ -178,6 +251,17 @@ function createShellHtml(config) {
           <span class="label">Workspace root</span>
           <code>${config.workspaceRoot}</code>
         </div>
+        <div class="card service-widget" data-service-widget>
+          <div class="service-widget__header">
+            <div>
+              <span class="label">Host-owned service widget</span>
+              <p>Reads the Service Lasso runtime API directly while keeping Service Admin separate.</p>
+            </div>
+            <button class="service-widget__refresh" type="button" data-service-refresh>Refresh</button>
+          </div>
+          <p class="service-widget__status" data-service-status>Loading runtime services...</p>
+          <ul class="service-list" data-service-list aria-live="polite"></ul>
+        </div>
         <div class="links">
           <a class="link" href="/api/host-status">
             <strong>Host status JSON</strong>
@@ -197,6 +281,85 @@ function createShellHtml(config) {
         <iframe title="Service Admin" src="/admin/"></iframe>
       </section>
     </main>
+    <script>
+      const statusElement = document.querySelector("[data-service-status]");
+      const listElement = document.querySelector("[data-service-list]");
+      const refreshButton = document.querySelector("[data-service-refresh]");
+
+      function lifecycleLabel(service) {
+        const lifecycle = service.lifecycle ?? {};
+        if (lifecycle.running) return "running";
+        if (lifecycle.configured) return "configured";
+        if (lifecycle.installed) return "installed";
+        return "discovered";
+      }
+
+      function healthLabel(service) {
+        if (!service.health) return "health unknown";
+        return service.health.healthy ? "healthy" : "needs attention";
+      }
+
+      function renderServices(services) {
+        listElement.replaceChildren();
+
+        if (services.length === 0) {
+          statusElement.textContent = "No services were discovered by the runtime.";
+          return;
+        }
+
+        statusElement.textContent = services.length === 1
+          ? "1 service discovered from the runtime API."
+          : services.length + " services discovered from the runtime API.";
+
+        for (const service of services) {
+          const row = document.createElement("li");
+          row.className = "service-row";
+
+          const health = healthLabel(service);
+          row.innerHTML = [
+            '<div class="service-row__top">',
+            '<div>',
+            '<div class="service-row__name"></div>',
+            '<div class="service-row__id"></div>',
+            '</div>',
+            '<span class="pill"></span>',
+            '</div>',
+            '<div class="service-row__detail"></div>',
+          ].join("");
+
+          row.querySelector(".service-row__name").textContent = service.name ?? service.id;
+          row.querySelector(".service-row__id").textContent = service.id;
+          row.querySelector(".pill").textContent = lifecycleLabel(service);
+          row.querySelector(".service-row__detail").textContent = health + " - " + (service.health?.detail ?? "No healthcheck has reported yet.");
+          row.querySelector(".service-row__detail").classList.toggle("pill--healthy", service.health?.healthy === true);
+          row.querySelector(".service-row__detail").classList.toggle("pill--unhealthy", service.health?.healthy === false);
+          listElement.append(row);
+        }
+      }
+
+      async function loadServices() {
+        statusElement.textContent = "Loading runtime services...";
+        refreshButton.disabled = true;
+
+        try {
+          const response = await fetch("/api/runtime-services");
+          if (!response.ok) {
+            throw new Error("Runtime services request failed with HTTP " + response.status);
+          }
+
+          const payload = await response.json();
+          renderServices(Array.isArray(payload.services) ? payload.services : []);
+        } catch (error) {
+          statusElement.textContent = "Unable to load runtime services: " + (error?.message ?? error);
+          listElement.replaceChildren();
+        } finally {
+          refreshButton.disabled = false;
+        }
+      }
+
+      refreshButton.addEventListener("click", loadServices);
+      loadServices();
+    </script>
   </body>
 </html>`;
 }
@@ -241,6 +404,34 @@ export function createHostStatus(config) {
   };
 }
 
+async function fetchRuntimeServices(config) {
+  const response = await fetch(`${config.runtimeUrl}/api/services`);
+  const body = await response.text();
+  let payload = null;
+
+  try {
+    payload = body ? JSON.parse(body) : null;
+  } catch {
+    payload = { raw: body };
+  }
+
+  if (!response.ok) {
+    return {
+      statusCode: response.status,
+      body: {
+        error: "runtime_services_unavailable",
+        message: `Runtime services API returned HTTP ${response.status}.`,
+        upstream: payload,
+      },
+    };
+  }
+
+  return {
+    statusCode: 200,
+    body: payload,
+  };
+}
+
 export function createWebHostServer(config) {
   const shellHtml = createShellHtml(config);
   const statusBody = createHostStatus(config);
@@ -257,6 +448,12 @@ export function createWebHostServer(config) {
 
     if (request.method === "GET" && url.pathname === "/api/host-status") {
       writeJson(response, 200, statusBody);
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/runtime-services") {
+      const result = await fetchRuntimeServices(config);
+      writeJson(response, result.statusCode, result.body);
       return;
     }
 

--- a/tests/host.test.js
+++ b/tests/host.test.js
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { once } from "node:events";
+import { createServer } from "node:http";
 import { resolveWebConfig, validateWebConfig } from "../src/config.js";
 import { createHostStatus, createWebHostServer } from "../src/server.js";
 
@@ -30,6 +31,33 @@ async function createFixtureRoots() {
     siblingRoot,
     adminDistRoot,
     sourceServicesRoot,
+  };
+}
+
+async function startRuntimeFixture(payload, statusCode = 200) {
+  const server = createServer((request, response) => {
+    if (request.method === "GET" && request.url === "/api/services") {
+      response.statusCode = statusCode;
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify(payload));
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end("not found");
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    async close() {
+      server.close();
+      await once(server, "close");
+    },
   };
 }
 
@@ -84,6 +112,8 @@ test("web host serves shell, host status, and mounted admin assets", async () =>
       assert.equal(shellResponse.status, 200);
       const shellHtml = await shellResponse.text();
       assert.match(shellHtml, /Browser-first shell for Service Lasso/);
+      assert.match(shellHtml, /Host-owned service widget/);
+      assert.match(shellHtml, /\/api\/runtime-services/);
       assert.match(shellHtml, /<iframe title="Service Admin" src="\/admin\/"><\/iframe>/);
 
       const statusResponse = await fetch(`${baseUrl}/api/host-status`);
@@ -105,6 +135,53 @@ test("web host serves shell, host status, and mounted admin assets", async () =>
       await once(server, "close");
     }
   } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("web host proxies runtime services for the host-owned widget", async () => {
+  const fixture = await createFixtureRoots();
+  const runtime = await startRuntimeFixture({
+    services: [
+      {
+        id: "echo-service",
+        name: "Echo Service",
+        lifecycle: { installed: true, configured: true, running: false },
+        health: { type: "process", healthy: true, detail: "Process is ready." },
+      },
+    ],
+  });
+
+  try {
+    const config = await validateWebConfig(
+      resolveWebConfig({
+        repoRoot: path.join(fixture.root, "service-lasso-app-web"),
+        siblingRoot: fixture.siblingRoot,
+        hostPort: 0,
+        runtimePort: Number(new URL(runtime.url).port),
+      }),
+    );
+    const server = createWebHostServer(config);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const servicesResponse = await fetch(`${baseUrl}/api/runtime-services`);
+      assert.equal(servicesResponse.status, 200);
+      const servicesBody = await servicesResponse.json();
+      assert.equal(servicesBody.services.length, 1);
+      assert.equal(servicesBody.services[0].id, "echo-service");
+      assert.equal(servicesBody.services[0].health.healthy, true);
+    } finally {
+      server.close();
+      await once(server, "close");
+    }
+  } finally {
+    await runtime.close();
     await rm(fixture.root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Adds a bounded host-owned service listing widget to the web shell.
- Adds a same-origin `/api/runtime-services` proxy that reads the Service Lasso runtime `/api/services` response.
- Updates POC/release docs to describe the widget as host-owned API proof, separate from Service Admin.

## Governance
- Issue: service-lasso/service-lasso#47 (`ISS-050`)
- Spec: `SPEC-002`, `AC-4W`

## Validation
- `npm test`
- `SERVICE_LASSO_RELEASE_VERSION=2026.4.23-abcdef1 npm run release:verify`