### PR TITLE
Refresh baseline service definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Current implementation:
 - host-owned landing shell at `/`
 - host-owned services widget that reads the runtime API through `/api/runtime-services`
 - embedded sibling `lasso-@serviceadmin` build at `/admin/`
-- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, and `@traefik`
+- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, `localcert`, `nginx`, and `@traefik`
 - manifest-owned Echo Service archive metadata under `services/echo-service/service.json`
-- manifest-owned Traefik archive metadata under `services/@traefik/service.json`
+- manifest-owned Traefik archive metadata under `services/@traefik/service.json`, with `localcert` and `nginx` declared as Traefik dependencies
+- `@node` and `@traefik` keep the `@` prefix because they are runtime/provider/infra service IDs; `echo-service`, `service-admin`, `localcert`, and `nginx` are normal managed service IDs
 - prepared local `servicesRoot` copied from the tracked service inventory before runtime startup
 
 Current local start command:

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -57,7 +57,8 @@ What ships:
 - generated `release-artifact.json`
 
 How it works:
-- the app repo owns the baseline `services/` inventory, including `echo-service`, `service-admin`, `@node`, and `@traefik`
+- the app repo owns the baseline `services/` inventory, including `echo-service`, `service-admin`, `@node`, `localcert`, `nginx`, and `@traefik`
+- `@traefik` declares `localcert` and `nginx` as dependencies in its manifest
 - release-backed manifests carry bounded `artifact` blocks pointing at their service release assets
 - on `install`, Service Lasso downloads and unpacks the matching archive from the manifest metadata
 - the app artifact itself does not ship the Echo Service archive
@@ -93,6 +94,7 @@ Honest label:
 
 The release now proves:
 - the repo owns explicit tracked service metadata under `services/`
+- the tracked service metadata includes the baseline Traefik dependency graph through `localcert` and `nginx`
 - the browser-first host can be packaged repeatably
 - the runnable artifact can boot Service Lasso and Service Admin without sibling-repo checkout tricks
 - the host shell includes a bounded service listing widget backed by the runtime API

--- a/scripts/release-artifact-lib.mjs
+++ b/scripts/release-artifact-lib.mjs
@@ -431,14 +431,19 @@ async function createVerificationReleaseFixture(rootDir, assetNameOverride = nul
 }
 
 async function acquireBundledServiceArchive(outputRoot, manifest, platform) {
+  const repo = manifest.artifact?.source?.repo;
   const releaseTag = manifest.artifact?.source?.tag;
   const platformArtifact = manifest.artifact?.platforms?.[platform] ?? manifest.artifact?.platforms?.default;
   const assetName = platformArtifact?.assetName;
-  const assetUrl = platformArtifact?.assetUrl;
+  const assetUrl =
+    platformArtifact?.assetUrl ??
+    (repo && releaseTag && assetName
+      ? `https://github.com/${repo}/releases/download/${encodeURIComponent(releaseTag)}/${encodeURIComponent(assetName)}`
+      : undefined);
 
   if (!releaseTag || !assetName || !assetUrl) {
     throw new Error(
-      `Cannot build bundled artifact for ${manifest.id}: service.json must define artifact.source.tag, assetName, and assetUrl.`,
+      `Cannot build bundled artifact for ${manifest.id}: service.json must define artifact.source.repo, artifact.source.tag, and assetName.`,
     );
   }
 

--- a/services/@node/service.json
+++ b/services/@node/service.json
@@ -1,13 +1,18 @@
 {
   "id": "@node",
   "name": "Node Runtime",
-  "description": "Local/no-download Node runtime provider used by Service Lasso managed services.",
-  "version": "0.1.0",
+  "description": "Release-backed Node.js runtime provider for Service Lasso services.",
+  "version": "v24.15.0",
+  "role": "provider",
   "enabled": true,
   "executable": "node",
   "args": ["--version"],
   "env": {
     "NODE_ENV": "development"
+  },
+  "globalenv": {
+    "NODE": "${SERVICE_ARTIFACT_COMMAND}",
+    "NODE_HOME": "${SERVICE_ARTIFACT_ROOT}"
   },
   "urls": [
     {
@@ -15,5 +20,33 @@
       "url": "https://nodejs.org",
       "kind": "external"
     }
-  ]
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-node",
+      "tag": "2026.4.27-eca215a"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-node-v24.15.0-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\node.exe",
+        "args": ["--version"]
+      },
+      "linux": {
+        "assetName": "lasso-node-v24.15.0-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./bin/node",
+        "args": ["--version"]
+      },
+      "darwin": {
+        "assetName": "lasso-node-v24.15.0-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./bin/node",
+        "args": ["--version"]
+      }
+    }
+  }
 }

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -2,37 +2,133 @@
   "id": "@traefik",
   "name": "Traefik Router",
   "description": "Release-backed Traefik edge/router service for Service Lasso baseline routing.",
-  "version": "2026.4.25-5301df9",
+  "version": "2026.4.27-bbc7f15",
   "enabled": true,
+  "depend_on": [
+    "localcert",
+    "nginx"
+  ],
   "ports": {
     "web": 19080,
-    "admin": 19081
+    "websecure": 19443,
+    "admin": 19081,
+    "https_traefik": 19082,
+    "https_nginx": 19090,
+    "https_cms": 19100,
+    "https_flow": 19110,
+    "https_flowtms": 19120,
+    "https_api": 19130,
+    "https_files": 19140,
+    "https_bpmn": 19150,
+    "mongo": 19160,
+    "typedb": 19170
   },
+  "portmapping": {
+    "HTTP": "${WEB_PORT}",
+    "HTTPS": "${WEBSECURE_PORT}",
+    "HTTPS_TRAEFIK": "${HTTPS_TRAEFIK_PORT}",
+    "HTTPS_NGINX": "${HTTPS_NGINX_PORT}",
+    "HTTPS_CMS": "${HTTPS_CMS_PORT}",
+    "HTTPS_FLOW": "${HTTPS_FLOW_PORT}",
+    "HTTPS_FLOWTMS": "${HTTPS_FLOWTMS_PORT}",
+    "HTTPS_API": "${HTTPS_API_PORT}",
+    "HTTPS_FILES": "${HTTPS_FILES_PORT}",
+    "HTTPS_BPMN": "${HTTPS_BPMN_PORT}",
+    "TCP_MOGNO": "${MONGO_PORT}",
+    "TCP_TYPEDB": "${TYPEDB_PORT}"
+  },
+  "commandline": {
+    "win32": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "darwin": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "linux": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}/runtime/dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true",
+    "default": " --log.level=DEBUG --providers.file.filename=\"${SERVICE_ROOT}\\runtime\\dynamic.yml\" --api.insecure=true --api.dashboard=true --entryPoints.web.address=\":${WEB_PORT}\" --entryPoints.websecure.address=\":${WEBSECURE_PORT}\" --entryPoints.traefik.address=\":${ADMIN_PORT}\" --entryPoints.httpsTraefik.address=\":${HTTPS_TRAEFIK_PORT}\" --entryPoints.httpsNginx.address=\":${HTTPS_NGINX_PORT}\" --entryPoints.httpsCms.address=\":${HTTPS_CMS_PORT}\" --entryPoints.httpsFlow.address=\":${HTTPS_FLOW_PORT}\" --entryPoints.httpsFlowtms.address=\":${HTTPS_FLOWTMS_PORT}\" --entryPoints.httpsApi.address=\":${HTTPS_API_PORT}\" --entryPoints.httpsFiles.address=\":${HTTPS_FILES_PORT}\" --entryPoints.httpsBpmn.address=\":${HTTPS_BPMN_PORT}\" --entryPoints.mongo.address=\":${MONGO_PORT}\" --entryPoints.typedb.address=\":${TYPEDB_PORT}\" --ping=true --ping.entryPoint=traefik --serversTransport.insecureSkipVerify=true"
+  },
+  "env": {
+    "TRAEFIK_HTTP_PORT": "${WEB_PORT}",
+    "TRAEFIK_HTTPS_PORT": "${WEBSECURE_PORT}",
+    "TRAEFIK_INTERNAL_PORT": "${ADMIN_PORT}",
+    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${HTTPS_TRAEFIK_PORT}",
+    "TRAEFIK_HTTPS_NGINX_PORT": "${HTTPS_NGINX_PORT}",
+    "TRAEFIK_HTTPS_CMS_PORT": "${HTTPS_CMS_PORT}",
+    "TRAEFIK_HTTPS_FLOW_PORT": "${HTTPS_FLOW_PORT}",
+    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${HTTPS_FLOWTMS_PORT}",
+    "TRAEFIK_HTTPS_API_PORT": "${HTTPS_API_PORT}",
+    "TRAEFIK_HTTPS_FILES_PORT": "${HTTPS_FILES_PORT}",
+    "TRAEFIK_HTTPS_BPMN_PORT": "${HTTPS_BPMN_PORT}",
+    "TRAEFIK_MONGO_PORT": "${MONGO_PORT}",
+    "TRAEFIK_TYPEDB_PORT": "${TYPEDB_PORT}",
+    "TRAEFIK_WEB_URL": "http://127.0.0.1:${WEB_PORT}/",
+    "TRAEFIK_WEBSECURE_URL": "https://127.0.0.1:${WEBSECURE_PORT}/",
+    "TRAEFIK_DASHBOARD_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+    "TRAEFIK_PING_URL": "http://127.0.0.1:${ADMIN_PORT}/ping"
+  },
+  "globalenv": {
+    "TRAEFIK_HTTP_PORT": "${WEB_PORT}",
+    "TRAEFIK_HTTPS_PORT": "${WEBSECURE_PORT}",
+    "TRAEFIK_INTERNAL_PORT": "${ADMIN_PORT}",
+    "TRAEFIK_HTTPS_TRAEFIK_PORT": "${HTTPS_TRAEFIK_PORT}",
+    "TRAEFIK_HTTPS_NGINX_PORT": "${HTTPS_NGINX_PORT}",
+    "TRAEFIK_HTTPS_CMS_PORT": "${HTTPS_CMS_PORT}",
+    "TRAEFIK_HTTPS_FLOW_PORT": "${HTTPS_FLOW_PORT}",
+    "TRAEFIK_HTTPS_FLOWTMS_PORT": "${HTTPS_FLOWTMS_PORT}",
+    "TRAEFIK_HTTPS_API_PORT": "${HTTPS_API_PORT}",
+    "TRAEFIK_HTTPS_FILES_PORT": "${HTTPS_FILES_PORT}",
+    "TRAEFIK_HTTPS_BPMN_PORT": "${HTTPS_BPMN_PORT}",
+    "TRAEFIK_MONGO_PORT": "${MONGO_PORT}",
+    "TRAEFIK_TYPEDB_PORT": "${TYPEDB_PORT}",
+    "TRAEFIK_WEB_URL": "http://127.0.0.1:${WEB_PORT}/",
+    "TRAEFIK_WEBSECURE_URL": "https://127.0.0.1:${WEBSECURE_PORT}/",
+    "TRAEFIK_DASHBOARD_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+    "TRAEFIK_PING_URL": "http://127.0.0.1:${ADMIN_PORT}/ping",
+    "TRAEFIK_TRAEFIK_URL": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+    "TRAEFIK_HOST_DOMAIN": "localhost",
+    "TRAEFIK_HOST_DOMAIN_URL": "localhost",
+    "TRAEFIK_HOST_DOMAIN_SUFFIX": "localhost"
+  },
+  "urls": [
+    {
+      "label": "dashboard",
+      "url": "http://127.0.0.1:${ADMIN_PORT}/dashboard/",
+      "kind": "local"
+    },
+    {
+      "label": "ping",
+      "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
+      "kind": "local"
+    },
+    {
+      "label": "web",
+      "url": "http://127.0.0.1:${WEB_PORT}/",
+      "kind": "local"
+    },
+    {
+      "label": "websecure",
+      "url": "https://127.0.0.1:${WEBSECURE_PORT}/",
+      "kind": "local"
+    }
+  ],
   "artifact": {
     "kind": "archive",
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-traefik",
-      "tag": "2026.4.25-5301df9"
+      "tag": "2026.4.27-bbc7f15"
     },
     "platforms": {
       "win32": {
         "assetName": "lasso-traefik-win32.zip",
-        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-win32.zip",
         "archiveType": "zip",
         "command": ".\\traefik.exe",
         "args": ["--configFile=runtime/traefik.yml"]
       },
       "linux": {
         "assetName": "lasso-traefik-linux.tar.gz",
-        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-linux.tar.gz",
         "archiveType": "tar.gz",
         "command": "./traefik",
         "args": ["--configFile=runtime/traefik.yml"]
       },
       "darwin": {
         "assetName": "lasso-traefik-darwin.tar.gz",
-        "assetUrl": "https://github.com/service-lasso/lasso-traefik/releases/download/2026.4.25-5301df9/lasso-traefik-darwin.tar.gz",
         "archiveType": "tar.gz",
         "command": "./traefik",
         "args": ["--configFile=runtime/traefik.yml"]
@@ -51,11 +147,15 @@
     "files": [
       {
         "path": "./runtime/traefik.yml",
-        "content": "entryPoints:\n  web:\n    address: \"127.0.0.1:${WEB_PORT}\"\n  traefik:\n    address: \"127.0.0.1:${ADMIN_PORT}\"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: \"./runtime/dynamic.yml\"\n    watch: true\nlog:\n  level: INFO\n"
+        "content": "entryPoints:\n  web:\n    address: \"127.0.0.1:${WEB_PORT}\"\n  websecure:\n    address: \"127.0.0.1:${WEBSECURE_PORT}\"\n  traefik:\n    address: \"127.0.0.1:${ADMIN_PORT}\"\n  httpsTraefik:\n    address: \"127.0.0.1:${HTTPS_TRAEFIK_PORT}\"\n  httpsNginx:\n    address: \"127.0.0.1:${HTTPS_NGINX_PORT}\"\n  httpsCms:\n    address: \"127.0.0.1:${HTTPS_CMS_PORT}\"\n  httpsFlow:\n    address: \"127.0.0.1:${HTTPS_FLOW_PORT}\"\n  httpsFlowtms:\n    address: \"127.0.0.1:${HTTPS_FLOWTMS_PORT}\"\n  httpsApi:\n    address: \"127.0.0.1:${HTTPS_API_PORT}\"\n  httpsFiles:\n    address: \"127.0.0.1:${HTTPS_FILES_PORT}\"\n  httpsBpmn:\n    address: \"127.0.0.1:${HTTPS_BPMN_PORT}\"\n  mongo:\n    address: \"127.0.0.1:${MONGO_PORT}\"\n  typedb:\n    address: \"127.0.0.1:${TYPEDB_PORT}\"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: \"./runtime/dynamic.yml\"\n    watch: true\nlog:\n  level: INFO\n"
       }
     ]
   },
   "healthcheck": {
-    "type": "process"
+    "type": "http",
+    "url": "http://127.0.0.1:${ADMIN_PORT}/ping",
+    "expected_status": 200,
+    "retries": 80,
+    "interval": 250
   }
 }

--- a/services/echo-service/service.json
+++ b/services/echo-service/service.json
@@ -1,60 +1,71 @@
 {
   "id": "echo-service",
   "name": "Echo Service",
-  "description": "Release-backed Echo Service harness for the app-web starter bootstrap-download flow.",
-  "version": "2026.4.20-a417abd",
+  "description": "Baseline Echo Service manifest. Core tests can run the checked-in fixture directly, while install can acquire the canonical Echo Service release artifact.",
+  "version": "0.3.0",
   "enabled": true,
+  "executable": "node",
+  "args": ["runtime/fixture-harness.mjs"],
+  "env": {
+    "ECHO_MESSAGE": "hello from echo-service harness",
+    "ECHO_PORT": "${SERVICE_PORT}",
+    "ECHO_LOG_PATH": "./runtime/echo.log",
+    "ECHO_STATE_PATH": "./runtime/state.json",
+    "ECHO_DB_PATH": "./runtime/echo.sqlite"
+  },
   "artifact": {
     "kind": "archive",
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-echoservice",
-      "tag": "2026.4.20-a417abd",
-      "serviceManifestAssetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/service.json"
+      "tag": "2026.4.20-a417abd"
     },
     "platforms": {
       "win32": {
         "assetName": "echo-service-win32.zip",
-        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-win32.zip",
         "archiveType": "zip",
-        "command": "./echo-service.exe",
-        "args": []
+        "command": ".\\echo-service.exe"
       },
       "linux": {
         "assetName": "echo-service-linux.tar.gz",
-        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-linux.tar.gz",
         "archiveType": "tar.gz",
-        "command": "./echo-service",
-        "args": []
+        "command": "./echo-service"
       },
       "darwin": {
         "assetName": "echo-service-darwin.tar.gz",
-        "assetUrl": "https://github.com/service-lasso/lasso-echoservice/releases/download/2026.4.20-a417abd/echo-service-darwin.tar.gz",
         "archiveType": "tar.gz",
-        "command": "./echo-service",
-        "args": []
+        "command": "./echo-service"
       }
     }
   },
-  "env": {
-    "ECHO_MESSAGE": "hello from service-lasso-app-web",
-    "ECHO_PORT": "4010",
-    "ECHO_HTTP_HEALTH_PORT": "4011",
-    "ECHO_TCP_PORT": "4012",
-    "ECHO_LOG_PATH": "./runtime/echo.log",
-    "ECHO_STATE_PATH": "./runtime/state.json",
-    "ECHO_DB_PATH": "./runtime/echo.sqlite",
-    "SERVICE_LASSO_GLOBAL_ENV_JSON": "{\"ECHO_ENV_CHANNEL\":\"app-web\"}"
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/install.txt",
+        "content": "installed ${SERVICE_ID}\n"
+      }
+    ]
+  },
+  "config": {
+    "files": [
+      {
+        "path": "./runtime/config.json",
+        "content": "{\n  \"serviceId\": \"${SERVICE_ID}\",\n  \"port\": \"${SERVICE_PORT}\",\n  \"logPath\": \"${ECHO_LOG_PATH}\",\n  \"statePath\": \"${ECHO_STATE_PATH}\",\n  \"dbPath\": \"${ECHO_DB_PATH}\"\n}\n"
+      }
+    ]
+  },
+  "ports": {
+    "service": 4010
   },
   "urls": [
     {
       "label": "ui",
-      "url": "http://127.0.0.1:4010/",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/",
       "kind": "local"
     },
     {
       "label": "service",
-      "url": "http://127.0.0.1:4010/health",
+      "url": "http://127.0.0.1:${SERVICE_PORT}/health",
       "kind": "local"
     }
   ],

--- a/services/localcert/service.json
+++ b/services/localcert/service.json
@@ -1,0 +1,38 @@
+{
+  "id": "localcert",
+  "name": "Core Local Certificate Utility",
+  "description": "Release-backed local certificate bootstrap utility for Service Lasso routing dependencies.",
+  "version": "0.1.0",
+  "role": "provider",
+  "enabled": true,
+  "globalenv": {
+    "LOCALCERT_ENABLED": "true",
+    "LOCALCERT_ROOT": "${SERVICE_ARTIFACT_ROOT}",
+    "CERT_FILE": "${SERVICE_ARTIFACT_ROOT}/runtime/certs/localhost.crt",
+    "CERT_KEY": "${SERVICE_ARTIFACT_ROOT}/runtime/certs/localhost.key",
+    "CERT_PFX": "${SERVICE_ARTIFACT_ROOT}/runtime/certs/localhost.pfx",
+    "CAROOT_CERT": "${SERVICE_ARTIFACT_ROOT}/runtime/certs/caroot.crt"
+  },
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-localcert",
+      "tag": "2026.4.27-591ed28"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-localcert-0.1.0-win32.zip",
+        "archiveType": "zip"
+      },
+      "linux": {
+        "assetName": "lasso-localcert-0.1.0-linux.tar.gz",
+        "archiveType": "tar.gz"
+      },
+      "darwin": {
+        "assetName": "lasso-localcert-0.1.0-darwin.tar.gz",
+        "archiveType": "tar.gz"
+      }
+    }
+  }
+}

--- a/services/nginx/service.json
+++ b/services/nginx/service.json
@@ -1,0 +1,101 @@
+{
+  "id": "nginx",
+  "name": "NGINX",
+  "description": "Release-backed NGINX Open Source service for local Service Lasso routing dependencies.",
+  "version": "1.30.0",
+  "enabled": true,
+  "ports": {
+    "http": 18080
+  },
+  "commandline": {
+    "win32": " -p \"${SERVICE_ROOT}\" -c \"runtime\\nginx.conf\" -g \"daemon off;\"",
+    "darwin": " -p \"${SERVICE_ROOT}\" -c \"runtime/nginx.conf\" -g \"daemon off;\"",
+    "linux": " -p \"${SERVICE_ROOT}\" -c \"runtime/nginx.conf\" -g \"daemon off;\"",
+    "default": " -p \"${SERVICE_ROOT}\" -c \"runtime/nginx.conf\" -g \"daemon off;\""
+  },
+  "env": {
+    "NGINX_HTTP_PORT": "${HTTP_PORT}",
+    "NGINX_URL": "http://127.0.0.1:${HTTP_PORT}/",
+    "NGINX_ROOT": "${SERVICE_ROOT}"
+  },
+  "globalenv": {
+    "NGINX_HTTP_PORT": "${HTTP_PORT}",
+    "NGINX_URL": "http://127.0.0.1:${HTTP_PORT}/",
+    "NGINX_ROOT": "${SERVICE_ROOT}"
+  },
+  "urls": [
+    {
+      "label": "health",
+      "url": "http://127.0.0.1:${HTTP_PORT}/health",
+      "kind": "local"
+    },
+    {
+      "label": "web",
+      "url": "http://127.0.0.1:${HTTP_PORT}/",
+      "kind": "local"
+    }
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-nginx",
+      "tag": "2026.4.27-712c75f"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "lasso-nginx-1.30.0-win32.zip",
+        "archiveType": "zip",
+        "command": ".\\nginx.exe",
+        "args": ["-v"]
+      },
+      "linux": {
+        "assetName": "lasso-nginx-1.30.0-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./sbin/nginx",
+        "args": ["-v"]
+      },
+      "darwin": {
+        "assetName": "lasso-nginx-1.30.0-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "./sbin/nginx",
+        "args": ["-v"]
+      }
+    }
+  },
+  "install": {
+    "files": [
+      {
+        "path": "./runtime/www/index.html",
+        "content": "<!doctype html>\n<html lang=\"en\">\n  <head><meta charset=\"utf-8\"><title>Service Lasso NGINX</title></head>\n  <body><h1>Service Lasso NGINX</h1><p>NGINX is running.</p></body>\n</html>\n"
+      },
+      {
+        "path": "./runtime/www/health",
+        "content": "ok\n"
+      },
+      {
+        "path": "./logs/.keep",
+        "content": ""
+      },
+      {
+        "path": "./temp/.keep",
+        "content": ""
+      }
+    ]
+  },
+  "config": {
+    "files": [
+      {
+        "path": "./runtime/nginx.conf",
+        "content": "worker_processes  1;\nmaster_process off;\nerror_log  logs/error.log info;\npid        runtime/nginx.pid;\n\nevents {\n  worker_connections  256;\n}\n\nhttp {\n  access_log logs/access.log;\n  default_type  application/octet-stream;\n  sendfile      on;\n  keepalive_timeout  30;\n\n  server {\n    listen 127.0.0.1:${HTTP_PORT};\n    server_name localhost;\n\n    location / {\n      root runtime/www;\n      index index.html;\n    }\n  }\n}\n"
+      }
+    ]
+  },
+  "healthcheck": {
+    "type": "http",
+    "url": "http://127.0.0.1:${HTTP_PORT}/health",
+    "expected_status": 200,
+    "retries": 80,
+    "interval": 250
+  }
+}

--- a/services/service-admin/service.json
+++ b/services/service-admin/service.json
@@ -1,14 +1,49 @@
 {
   "id": "service-admin",
-  "name": "Service Admin",
-  "description": "Embedded Service Admin UI surfaced by the app-web starter host.",
+  "name": "Core Service Admin",
+  "description": "Core operator/admin UI service backed by the canonical lasso-serviceadmin release artifact.",
   "version": "0.1.0",
-  "enabled": false,
+  "enabled": true,
+  "depend_on": ["@node"],
+  "ports": {
+    "ui": 17700
+  },
   "urls": [
     {
       "label": "ui",
-      "url": "http://127.0.0.1:19120/admin/",
+      "url": "http://127.0.0.1:${UI_PORT}/",
       "kind": "local"
     }
-  ]
+  ],
+  "artifact": {
+    "kind": "archive",
+    "source": {
+      "type": "github-release",
+      "repo": "service-lasso/lasso-serviceadmin",
+      "tag": "2026.4.18-170a1af"
+    },
+    "platforms": {
+      "win32": {
+        "assetName": "@serviceadmin-win32.zip",
+        "archiveType": "zip",
+        "command": "node",
+        "args": ["runtime/server.js"]
+      },
+      "linux": {
+        "assetName": "@serviceadmin-linux.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "node",
+        "args": ["runtime/server.js"]
+      },
+      "darwin": {
+        "assetName": "@serviceadmin-darwin.tar.gz",
+        "archiveType": "tar.gz",
+        "command": "node",
+        "args": ["runtime/server.js"]
+      }
+    }
+  },
+  "healthcheck": {
+    "type": "process"
+  }
 }


### PR DESCRIPTION
## Summary
- refresh the baseline services inventory to match core Service Lasso definitions
- add localcert and nginx manifests required by the Traefik dependency graph
- update bundled release packaging to derive GitHub asset URLs from service.json repo/tag/assetName metadata

## Validation
- npm test
- npm run release:verify