### PR TITLE
fix: use core service id prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Current implementation:
 - host-owned landing shell at `/`
 - host-owned services widget that reads the runtime API through `/api/runtime-services`
 - embedded sibling `lasso-@serviceadmin` build at `/admin/`
-- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, `localcert`, `nginx`, and `@traefik`
+- tracked repo-owned baseline `services/` definitions for Echo Service, Service Admin, `@node`, `@localcert`, `@nginx`, and `@traefik`
 - manifest-owned Echo Service archive metadata under `services/echo-service/service.json`
-- manifest-owned Traefik archive metadata under `services/@traefik/service.json`, with `localcert` and `nginx` declared as Traefik dependencies
-- `@node` and `@traefik` keep the `@` prefix because they are runtime/provider/infra service IDs; `echo-service`, `service-admin`, `localcert`, and `nginx` are normal managed service IDs
+- manifest-owned Traefik archive metadata under `services/@traefik/service.json`, with `@localcert` and `@nginx` declared as Traefik dependencies
+- core Service Lasso services use the `@` prefix: `@node`, `@localcert`, `@nginx`, `@traefik`, and `@serviceadmin`; `echo-service` stays unprefixed because it is the sample/test managed service
 - prepared local `servicesRoot` copied from the tracked service inventory before runtime startup
 
 Current local start command:

--- a/docs/release-artifact.md
+++ b/docs/release-artifact.md
@@ -57,8 +57,8 @@ What ships:
 - generated `release-artifact.json`
 
 How it works:
-- the app repo owns the baseline `services/` inventory, including `echo-service`, `service-admin`, `@node`, `localcert`, `nginx`, and `@traefik`
-- `@traefik` declares `localcert` and `nginx` as dependencies in its manifest
+- the app repo owns the baseline `services/` inventory, including `echo-service`, `@serviceadmin`, `@node`, `@localcert`, `@nginx`, and `@traefik`
+- `@traefik` declares `@localcert` and `@nginx` as dependencies in its manifest
 - release-backed manifests carry bounded `artifact` blocks pointing at their service release assets
 - on `install`, Service Lasso downloads and unpacks the matching archive from the manifest metadata
 - the app artifact itself does not ship the Echo Service archive
@@ -94,7 +94,7 @@ Honest label:
 
 The release now proves:
 - the repo owns explicit tracked service metadata under `services/`
-- the tracked service metadata includes the baseline Traefik dependency graph through `localcert` and `nginx`
+- the tracked service metadata includes the baseline Traefik dependency graph through `@localcert` and `@nginx`
 - the browser-first host can be packaged repeatably
 - the runnable artifact can boot Service Lasso and Service Admin without sibling-repo checkout tricks
 - the host shell includes a bounded service listing widget backed by the runtime API

--- a/services/@localcert/service.json
+++ b/services/@localcert/service.json
@@ -1,5 +1,5 @@
 {
-  "id": "localcert",
+  "id": "@localcert",
   "name": "Core Local Certificate Utility",
   "description": "Release-backed local certificate bootstrap utility for Service Lasso routing dependencies.",
   "version": "0.1.0",

--- a/services/@nginx/service.json
+++ b/services/@nginx/service.json
@@ -1,5 +1,5 @@
 {
-  "id": "nginx",
+  "id": "@nginx",
   "name": "NGINX",
   "description": "Release-backed NGINX Open Source service for local Service Lasso routing dependencies.",
   "version": "1.30.0",

--- a/services/@serviceadmin/service.json
+++ b/services/@serviceadmin/service.json
@@ -1,5 +1,5 @@
 {
-  "id": "service-admin",
+  "id": "@serviceadmin",
   "name": "Core Service Admin",
   "description": "Core operator/admin UI service backed by the canonical lasso-serviceadmin release artifact.",
   "version": "0.1.0",

--- a/services/@traefik/service.json
+++ b/services/@traefik/service.json
@@ -5,8 +5,8 @@
   "version": "2026.4.27-bbc7f15",
   "enabled": true,
   "depend_on": [
-    "localcert",
-    "nginx"
+    "@localcert",
+    "@nginx"
   ],
   "ports": {
     "web": 19080,

--- a/src/config.js
+++ b/src/config.js
@@ -51,7 +51,7 @@ export function resolveWebConfig(options = {}) {
 
 export async function validateWebConfig(config) {
   await access(path.join(config.sourceServicesRoot, "echo-service", "service.json"));
-  await access(path.join(config.sourceServicesRoot, "service-admin", "service.json"));
+  await access(path.join(config.sourceServicesRoot, "@serviceadmin", "service.json"));
   await access(path.join(config.adminDistRoot, "index.html"));
   return config;
 }

--- a/src/services-root.js
+++ b/src/services-root.js
@@ -7,7 +7,7 @@ export async function prepareStarterServicesRoot(config) {
   return {
     servicesRoot: config.servicesRoot,
     echoServiceRoot: path.join(config.servicesRoot, "echo-service"),
-    serviceAdminRoot: path.join(config.servicesRoot, "service-admin"),
+    serviceAdminRoot: path.join(config.servicesRoot, "@serviceadmin"),
     echoServiceManifestPath: path.join(config.servicesRoot, "echo-service", "service.json"),
   };
 }

--- a/tests/host.test.js
+++ b/tests/host.test.js
@@ -16,7 +16,7 @@ async function createFixtureRoots() {
 
   await mkdir(adminDistRoot, { recursive: true });
   await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
-  await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
+  await mkdir(path.join(sourceServicesRoot, "@serviceadmin"), { recursive: true });
   await writeFile(path.join(adminDistRoot, "index.html"), "<!doctype html><title>admin</title>", "utf8");
   await writeFile(path.join(adminDistRoot, "asset.js"), "console.log('admin asset');", "utf8");
   await writeFile(
@@ -24,7 +24,7 @@ async function createFixtureRoots() {
     "{\n  \"id\": \"echo-service\",\n  \"artifact\": {\n    \"kind\": \"archive\"\n  }\n}\n",
     "utf8",
   );
-  await writeFile(path.join(sourceServicesRoot, "service-admin", "service.json"), "{\n  \"id\": \"service-admin\"\n}\n", "utf8");
+  await writeFile(path.join(sourceServicesRoot, "@serviceadmin", "service.json"), "{\n  \"id\": \"@serviceadmin\"\n}\n", "utf8");
 
   return {
     root,

--- a/tests/services-root.test.js
+++ b/tests/services-root.test.js
@@ -12,7 +12,7 @@ test("web starter servicesRoot is prepared from tracked service manifests withou
 
   try {
     await mkdir(path.join(sourceServicesRoot, "echo-service"), { recursive: true });
-    await mkdir(path.join(sourceServicesRoot, "service-admin"), { recursive: true });
+    await mkdir(path.join(sourceServicesRoot, "@serviceadmin"), { recursive: true });
     await writeFile(
       path.join(sourceServicesRoot, "echo-service", "service.json"),
       `${JSON.stringify(
@@ -49,8 +49,8 @@ test("web starter servicesRoot is prepared from tracked service manifests withou
       "utf8",
     );
     await writeFile(
-      path.join(sourceServicesRoot, "service-admin", "service.json"),
-      "{\n  \"id\": \"service-admin\",\n  \"enabled\": false\n}\n",
+      path.join(sourceServicesRoot, "@serviceadmin", "service.json"),
+      "{\n  \"id\": \"@serviceadmin\",\n  \"enabled\": false\n}\n",
       "utf8",
     );
 
@@ -60,13 +60,13 @@ test("web starter servicesRoot is prepared from tracked service manifests withou
     });
 
     assert.equal(prepared.echoServiceRoot, path.join(servicesRoot, "echo-service"));
-    assert.equal(prepared.serviceAdminRoot, path.join(servicesRoot, "service-admin"));
+    assert.equal(prepared.serviceAdminRoot, path.join(servicesRoot, "@serviceadmin"));
     const manifest = JSON.parse(await readFile(path.join(servicesRoot, "echo-service", "service.json"), "utf8"));
     assert.equal(manifest.id, "echo-service");
     assert.equal(manifest.artifact.source.repo, "service-lasso/lasso-echoservice");
     assert.equal(prepared.echoServiceManifestPath, path.join(servicesRoot, "echo-service", "service.json"));
-    const adminManifest = JSON.parse(await readFile(path.join(servicesRoot, "service-admin", "service.json"), "utf8"));
-    assert.equal(adminManifest.id, "service-admin");
+    const adminManifest = JSON.parse(await readFile(path.join(servicesRoot, "@serviceadmin", "service.json"), "utf8"));
+    assert.equal(adminManifest.id, "@serviceadmin");
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Mirrors service-lasso/service-lasso#216.

## Change
- Renames core-owned service folders/manifests to `@localcert`, `@nginx`, and `@serviceadmin`.
- Updates app config/tests/docs to resolve `@serviceadmin` and the prefixed core baseline IDs.

## Verification
- `npm test`
- `npm run release:verify`